### PR TITLE
Use container level matadatas to keep the migration status

### DIFF
--- a/ams/AssetMigrationTracker.cs
+++ b/ams/AssetMigrationTracker.cs
@@ -1,4 +1,5 @@
 ﻿using AMSMigrate.Contracts;
+using Azure.ResourceManager.Models;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 
@@ -6,46 +7,128 @@ namespace AMSMigrate.Ams
 {
     class AssetMigrationResult : MigrationResult
     {
-        public Uri? Uri { get; set; }
+        public const string AssetType_NonIsm = "non_ism";
+        public const string AssetType_Encrypted = "encrypted";
+        public const string AssetType_DmtGenerated = "dmt_generated";
+
+
+        /// <summary>
+        /// The asset type for the input asset, it is the value of "format" meta in .ism file if it exists,
+        /// or other dedicated value when .ism file doesn't exist, such as "non_ism", "encrypted", "dmt_migrated" etc.
+        /// </summary>
+        public string? AssetType { get; set; }
+
+        /// <summary>
+        /// The manifest name without the extension .ism,  it is set only when the input asset contains .ism file.
+        /// The ManifestName can be used to generate the final streaming URL for generated asset.
+        /// </summary>
+        public string? ManifestName { get; set; }
+
+        /// <summary>
+        /// The base URL for the generated asset, it could use a single storage container, or a sub-folder of the shared storage container.
+        /// The URL is in format of https://{storage_account}.blob.core.windows.net/{containerName}/{sub_folder}/
+        /// If the generated asset uses its own container, the {sub_folder} will be empty.
+        /// </summary>
+        public Uri? OutputPath { get; set; }
 
         public new MigrationStatus Status { get => base.Status; set => base.Status = value; }
 
-        public AssetMigrationResult(MigrationStatus status = MigrationStatus.Skipped, Uri? uri = null) : base(status)
+        /// <summary>
+        /// Determine if the input asset is streamable.
+        /// </summary>
+        public bool IsStreamable => (Status != MigrationStatus.Failed && AssetType != null && AssetType != AssetType_NonIsm);
+
+        /// <summary>
+        /// Determine if the asset can be migrated.
+        /// The current supprted scenarios:
+        /// 
+        ///   If it has .ism file, only mp4 format is supported.
+        ///   If there is no .ism file,  it can be copied over directly.
+        ///   
+        /// </summary>
+        public bool IsSupportedAsset => (AssetType != null && (AssetType == AssetType_NonIsm || AssetType.StartsWith("mp4")));
+
+        public AssetMigrationResult(MigrationStatus status = MigrationStatus.NotMigrated, Uri? outputPath = null, string? assetType = null, string? manifestName = null) : base(status)
         {
-            Uri = uri;
+            AssetType = assetType;
+            ManifestName = manifestName;
+            OutputPath = outputPath;
         }
     }
 
     internal class AssetMigrationTracker : IMigrationTracker<BlobContainerClient, AssetMigrationResult>
     {
-        public const string StatusKey = "status";
-        public const string UrlKey = "url";
-        public const string MigratedBlobName = "__migrated";
+        internal const string AssetTypeKey = "AssetType";
+        internal const string MigrateResultKey = "MigrateResult";
+        internal const string ManifestNameKey = "ManifestName";
+        internal const string OutputPathKey = "OutputPath";
 
         public async Task<AssetMigrationResult> GetMigrationStatusAsync(BlobContainerClient container, CancellationToken cancellationToken)
         {
             BlobContainerProperties properties = await container.GetPropertiesAsync(cancellationToken: cancellationToken);
-            if (!properties.Metadata.TryGetValue(StatusKey, out var value) ||
-                !Enum.TryParse<MigrationStatus>(value, out var status))
+            var metadataList = properties.Metadata;
+
+            Uri? outputPath = null;
+            string? assetType = null;
+            string? manifestName = null;
+            MigrationStatus status = MigrationStatus.NotMigrated;
+
+            if (metadataList != null && metadataList.Count > 0)
             {
-                status = MigrationStatus.NotMigrated;
-            }
-            Uri? uri = null;
-            if (properties.Metadata.TryGetValue(UrlKey, out var uriValue) && !string.IsNullOrEmpty(uriValue))
-            {
-                uri = new Uri(uriValue, UriKind.Absolute);
+                if (metadataList.TryGetValue(MigrateResultKey, out var value) && !string.IsNullOrEmpty(value))
+                {
+                    status = (MigrationStatus) Enum.Parse(typeof(MigrationStatus), value);
+                }
+
+                metadataList.TryGetValue(AssetTypeKey, out assetType);
+
+                metadataList.TryGetValue(ManifestNameKey, out manifestName);
+
+                if (metadataList.TryGetValue(OutputPathKey, out value) && !string.IsNullOrEmpty(value))
+                {
+                    outputPath = new Uri(value, UriKind.Absolute);
+                }
             }
 
-            return new AssetMigrationResult(status, uri);
+            return new AssetMigrationResult(status, outputPath, assetType, manifestName);
         }
 
         public async Task UpdateMigrationStatus(BlobContainerClient container, AssetMigrationResult result, CancellationToken cancellationToken)
         {
-            var metadata = new Dictionary<string, string>
+            var metadata = new Dictionary<string, string>();
+
+            switch (result.Status)
             {
-                { "status", result.Status.ToString() },
-                { "url", result.Uri?.ToString() ?? string.Empty }
-            };
+                // Report the same value in metadata for Completed and AlreadyMigrated.
+                case MigrationStatus.Completed:
+                case MigrationStatus.AlreadyMigrated:
+
+                    metadata.Add(MigrateResultKey, "Completed");
+                    break;
+
+                case MigrationStatus.Failed:
+                    metadata.Add(MigrateResultKey, "Failed");
+                    break;
+                default:
+                    // Don't put value for all other status in the metadata list.
+                    break;
+            }
+
+            if (!string.IsNullOrEmpty(result.AssetType))
+            {
+                metadata.Add(AssetTypeKey, result.AssetType);
+            }
+
+            if (!string.IsNullOrEmpty(result.ManifestName))
+            {
+                metadata.Add(ManifestNameKey, result.ManifestName);
+            }
+
+            if (result.OutputPath != null)
+            {
+                metadata.Add(OutputPathKey, result.OutputPath.AbsoluteUri);
+            }
+
             await container.SetMetadataAsync(metadata, cancellationToken: cancellationToken);
         }
     }

--- a/ams/ReportGenerator.cs
+++ b/ams/ReportGenerator.cs
@@ -68,8 +68,8 @@ namespace AMSMigrate.Ams
             foreach (var result in results)
             {
                 _writer.Write($"<tr><td>{result.AssetName}</td><td>{result.Status}</td><td>");
-                if (result.Uri != null)
-                    _writer.Write($"<a href=\"{result.Uri}\">{result.Uri}</a>");
+                if (result.OutputPath != null)
+                    _writer.Write($"<a href=\"{result.OutputPath}\">{result.OutputPath}</a>");
                 _writer.WriteLine($"</td></tr>");
             }
         }

--- a/azure/AzureStorageUploader.cs
+++ b/azure/AzureStorageUploader.cs
@@ -1,4 +1,5 @@
-﻿using AMSMigrate.Contracts;
+﻿using AMSMigrate.Ams;
+using AMSMigrate.Contracts;
 using Azure;
 using Azure.Core;
 using Azure.Storage.Blobs;
@@ -68,6 +69,25 @@ namespace AMSMigrate.Azure
             var outputBlob = container.GetBlockBlobClient(fileName);
             var operation = await outputBlob.StartCopyFromUriAsync(blob.Uri, cancellationToken: cancellationToken);
             await operation.WaitForCompletionAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Mark the status on the container for the generated assets.
+        /// </summary>
+        /// <param name="container">The name of the output container</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public async Task UpdateOutputStatus(
+            string containerName,
+            CancellationToken cancellationToken)
+        {
+            var container = _blobServiceClient.GetBlobContainerClient(containerName);
+            var metadata = new Dictionary<string, string>();
+
+            // Mark the asset type as "dmt_generated"
+            metadata.Add(AssetMigrationTracker.AssetTypeKey, AssetMigrationResult.AssetType_DmtGenerated);
+
+            await container.SetMetadataAsync(metadata, cancellationToken: cancellationToken);
         }
     }
 }

--- a/contracts/IFileUploader.cs
+++ b/contracts/IFileUploader.cs
@@ -11,5 +11,9 @@ namespace AMSMigrate.Contracts
             Stream content,
             IProgress<long> progress,
             CancellationToken cancellationToken);
+
+        Task UpdateOutputStatus(
+            string containerName,
+            CancellationToken cancellationToken);
     }
 }

--- a/contracts/MigrationStatus.cs
+++ b/contracts/MigrationStatus.cs
@@ -4,8 +4,8 @@ namespace AMSMigrate.Contracts
     public enum MigrationStatus
     {
         NotMigrated,
-        Success,
-        Failure,
+        Completed,
+        Failed,
         Skipped,
         AlreadyMigrated
     }

--- a/local/LocalFileUploader.cs
+++ b/local/LocalFileUploader.cs
@@ -1,4 +1,6 @@
-﻿using AMSMigrate.Contracts;
+﻿using AMSMigrate.Ams;
+using AMSMigrate.Contracts;
+using Azure.Storage.Blobs;
 using Microsoft.Extensions.Logging;
 
 namespace AMSMigrate.Local
@@ -37,5 +39,15 @@ namespace AMSMigrate.Local
             using var file = File.OpenWrite(Path.Combine(baseDir, Path.GetFileName(fileName)));
             await content.CopyToAsync(file, cancellationToken);
         }
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+        public async Task UpdateOutputStatus(
+            string containerName,
+            CancellationToken cancellationToken)
+        {
+            // Make it no op for local file provider.
+            return;
+        }
+#pragma warning restore CS1998
     }
 }

--- a/transform/AnalyzeTransform.cs
+++ b/transform/AnalyzeTransform.cs
@@ -7,21 +7,20 @@ namespace AMSMigrate.Transform
 {
     class AnalysisResult : AssetMigrationResult
     {
-        public AnalysisResult(string assetName, string? format, int locators, MigrationStatus status, Uri? uri = null)
-            : base(status, uri)
+        public AnalysisResult(string assetName, MigrationStatus status, int locators, Uri? outputPath = null, string? assetType = null, string? manifestName = null)
+            : base(status, outputPath, assetType, manifestName)
         {
             AssetName = assetName;
-            Format = format;
             Locators = locators;
         }
 
-        public string? Format { get; }
-
         public int Locators { get; internal set; }
 
-        public string AssetName { get; set; }
+        public string AssetName { get; set; }        
     }
     
+    /* TODO:  This class is not required anymore.
+     
     internal class AnalyzeTransform : ITransform<AssetDetails, AnalysisResult>
     {
         private readonly ILogger _logger;
@@ -40,7 +39,7 @@ namespace AMSMigrate.Transform
             var (assetName, container, manifest, _) = asset;
             // Check if already migrated.
             var status = await _tracker.GetMigrationStatusAsync(container, cancellationToken);
-            return new AnalysisResult(assetName, manifest?.Format, 0, status.Status);
+            return new AnalysisResult(assetName, status.Status, 0, status.OutputPath, status.AssetType, status.ManifestName);
         }
-    }
+    } */
 }

--- a/transform/UploadTransform.cs
+++ b/transform/UploadTransform.cs
@@ -1,6 +1,7 @@
 ﻿using AMSMigrate.Ams;
 using AMSMigrate.Contracts;
 using Microsoft.Extensions.Logging;
+using System.ComponentModel;
 
 namespace AMSMigrate.Transform
 {
@@ -28,6 +29,10 @@ namespace AMSMigrate.Transform
             var inputBlobs = await inputContainer.GetListOfBlobsAsync(cancellationToken, manifest);
             var uploads = inputBlobs.Select(blob => UploadBlobAsync(blob, outputPath, cancellationToken));
             await Task.WhenAll(uploads);
+
+            // Mark the output container appropriately so that it won't be used as an input asset in new run.
+            await UpdateOutputStatus(outputPath.Container, cancellationToken);
+
             return outputPath.Prefix;
         }
     }


### PR DESCRIPTION
Description:

  Below new metadatas are added into input asset's container:

     MigrateResult:  Completed or Failed.
     AssetType:  valid format in .ism file, plus below special cases:
                 "non_ism" when the input asset doesn't have .ism file.
                 "encrypted" when the asset is encrypted in container.
                 "dmt_generated", the container just holds the generated assets.

     ManifestName:  The manifest file name without extension .ism.
     OutputPath:    A URL in format of https://{storage_endpoint}/{output_container}/{sub_folder_forOutput}/

    When the value is not ready, the metadata can be removed from the container.

  Update class AssetMigrationResult so that it can report info
  like whether the asset is streamable, or it can be skipped at the curret milestone.

  Command Analyze can check the metadata list at the begining for the input assets, checks the detail asset info
  only when the migration is not completed nor failed.

  Command "assets" and "storage" can check the status in the begining and then update the metadata list at the end when the operation is completed or failed.

  The report of all commands keep the same behavior as today.