### PR TITLE
mark NotMigrated asset as Skipped instead of Failed.

### DIFF
--- a/ams/AssetMigrator.cs
+++ b/ams/AssetMigrator.cs
@@ -101,6 +101,9 @@ namespace AMSMigrate.Ams
                         case MigrationStatus.AlreadyMigrated:
                             ++stats.Migrated;
                             break;
+                        case MigrationStatus.NotMigrated:
+                            ++stats.Skipped;
+                            break;
                         default:
                             ++stats.Failed;
                             break;


### PR DESCRIPTION
when --copy-nonstreamable optiion is set to False, non-ism assets will not be copied and the results of the job is NotMigrated. Translate this status to stats.Skipped instead of stats.Failed.