### PR TITLE
Fix hang when running pacakger

### DIFF
--- a/ams/TemplateMapper.cs
+++ b/ams/TemplateMapper.cs
@@ -100,12 +100,12 @@ namespace AMSMigrate.Ams
             var index = path.IndexOf('/');
             if (index == -1)
             {
-                containerName = path;
+                containerName = path.ToLowerInvariant();
                 path = string.Empty;
             }
             else
             {
-                containerName = path.Substring(0, index);
+                containerName = path.Substring(0, index).ToLowerInvariant();
                 path = path.Substring(index + 1);
                 if (!path.EndsWith('/'))
                 {

--- a/pipes/BlobSource.cs
+++ b/pipes/BlobSource.cs
@@ -58,9 +58,7 @@ namespace AMSMigrate.Pipes
 
         public async Task DownloadAsync(string filePath, CancellationToken cancellationToken)
         {
-            BlobDownloadStreamingResult result = await _blobClient.DownloadStreamingAsync(cancellationToken: cancellationToken);
-            using var file = File.OpenWrite(filePath);
-            await WriteAsync(file, cancellationToken);
+            await _blobClient.DownloadToAsync(filePath, cancellationToken);
         }
     }
 }


### PR DESCRIPTION
When any task fails cancel all taks as  tasks can be hung on pipes. Fix the console logging to use log level passed and allow interactive login. When downloading to local file use parallel download to make it faster.