### PR TITLE
Add options --creation-time-start and --creation-time-end to command …

### DIFF
--- a/AnalysisOptionsBinder.cs
+++ b/AnalysisOptionsBinder.cs
@@ -14,6 +14,22 @@ namespace AMSMigrate
             Arity = ArgumentArity.ExactlyOne
         };
 
+        private readonly Option<DateTimeOffset?> _creationTimeStart = new Option<DateTimeOffset?>(
+            aliases: new[] { "--creation-time-start", "-cs" },
+            description: @"The earliest creation time of the selected assets in UTC, 
+format is yyyy-MM-ddThh:mm:ssZ, the hh:mm:ss is optional.")
+        {
+            Arity = ArgumentArity.ZeroOrOne
+        };
+
+        private readonly Option<DateTimeOffset?> _creationTimeEnd = new Option<DateTimeOffset?>(
+            aliases: new[] { "--creation-time-end", "-ce" },
+            description: @"The latest creation time of the selected assets in UTC, 
+format is yyyy-MM-ddThh:mm:ssZ, the hh:mm:ss is optional.")
+        {
+            Arity = ArgumentArity.ZeroOrOne
+        };
+
         private readonly Option<string?> _filter = new Option<string?>(
             aliases: new[] { "--resource-filter", "-f" },
             description: @"An ODATA condition to filter the resources only when the source account is for media service.
@@ -46,6 +62,8 @@ Report - A migration report")
         {
             var command = new Command(name, description);
             command.AddOption(_sourceAccount);
+            command.AddOption(_creationTimeStart);
+            command.AddOption(_creationTimeEnd);
             command.AddOption(_filter);
             command.AddOption(_analysisType);
             command.AddOption(_batchSize);
@@ -56,6 +74,8 @@ Report - A migration report")
         {
             return new AnalysisOptions(
                 bindingContext.ParseResult.GetValueForOption(_sourceAccount)!,
+                bindingContext.ParseResult.GetValueForOption(_creationTimeStart),
+                bindingContext.ParseResult.GetValueForOption(_creationTimeEnd),
                 bindingContext.ParseResult.GetValueForOption(_filter),
                 bindingContext.ParseResult.GetValueForOption(_analysisType),
                 bindingContext.ParseResult.GetValueForOption(_batchSize)

--- a/AssetOptionsBinder.cs
+++ b/AssetOptionsBinder.cs
@@ -36,6 +36,22 @@ e.g., videos/${AssetName} will upload to a container named 'videos' with path be
             Arity = ArgumentArity.ZeroOrOne
         };
 
+        private readonly Option<DateTimeOffset?> _creationTimeStart = new Option<DateTimeOffset?>(
+            aliases: new[] { "--creation-time-start", "-cs" },
+            description: @"The earliest creation time of the selected assets in UTC, 
+format is yyyy-MM-ddThh:mm:ssZ, the hh:mm:ss is optional.")
+        {
+            Arity = ArgumentArity.ZeroOrOne
+        };
+
+        private readonly Option<DateTimeOffset?> _creationTimeEnd = new Option<DateTimeOffset?>(
+            aliases: new[] { "--creation-time-end", "-ce" },
+            description: @"The latest creation time of the selected assets in UTC, 
+format is yyyy-MM-ddThh:mm:ssZ, the hh:mm:ss is optional.")
+        {
+            Arity = ArgumentArity.ZeroOrOne
+        };
+
         private readonly Option<string?> _filter = new Option<string?>(
             aliases: new[] { "--resource-filter", "-f" },
             description: @"An ODATA condition to filter the resources.
@@ -125,6 +141,8 @@ Visit https://learn.microsoft.com/en-us/azure/media-services/latest/filter-order
             command.AddOption(_sourceAccount);
             command.AddOption(_storageAccount);
             command.AddOption(_pathTemplate);
+            command.AddOption(_creationTimeStart);
+            command.AddOption(_creationTimeEnd);
             command.AddOption(_filter);
             command.AddOption(_overwrite);
             command.AddOption(_markComplete);
@@ -146,6 +164,8 @@ Visit https://learn.microsoft.com/en-us/azure/media-services/latest/filter-order
                 bindingContext.ParseResult.GetValueForOption(_storageAccount)!,
                 bindingContext.ParseResult.GetValueForOption(_packagerType),
                 bindingContext.ParseResult.GetValueForOption(_pathTemplate)!,
+                bindingContext.ParseResult.GetValueForOption(_creationTimeStart),
+                bindingContext.ParseResult.GetValueForOption(_creationTimeEnd),
                 bindingContext.ParseResult.GetValueForOption(_filter),
                 workingDirectory,
                 bindingContext.ParseResult.GetValueForOption(_copyNonStreamable),

--- a/ams/AssetAnalyzer.cs
+++ b/ams/AssetAnalyzer.cs
@@ -112,6 +112,10 @@ namespace AMSMigrate.Ams
             var storage = await _resourceProvider.GetStorageAccountAsync(account, cancellationToken);
             ReportGenerator? reportGenerator = null;
 
+            var resourceFilter = GetAssetResourceFilter(_analysisOptions.ResourceFilter,
+                                                        _analysisOptions.CreationTimeStart,
+                                                        _analysisOptions.CreationTimeEnd);
+
             if (_analysisOptions.AnalysisType == AnalysisType.Report)
             {
                 var file = File.OpenWrite(Path.Combine(_globalOptions.LogDirectory, $"Report_{DateTime.Now:hh-mm-ss}.html"));
@@ -119,13 +123,13 @@ namespace AMSMigrate.Ams
                 reportGenerator.WriteHeader();
             }
             var assets = account.GetMediaAssets()
-                .GetAllAsync(_analysisOptions.ResourceFilter, cancellationToken: cancellationToken);
+                .GetAllAsync(resourceFilter, cancellationToken: cancellationToken);
             var statistics = new Statistics();
             var assetTypes = new SortedDictionary<string, int>();
 
             List<MediaAssetResource>? filteredList = null;
 
-            if (_analysisOptions.ResourceFilter != null)
+            if (resourceFilter != null)
             {
                 // When a filter is used, it usually inlcude a small list of assets,
                 // The total count of asset can be extracted in advance without much perf hit.

--- a/ams/AssetMigrator.cs
+++ b/ams/AssetMigrator.cs
@@ -49,13 +49,17 @@ namespace AMSMigrate.Ams
 
             _logger.LogInformation("The total asset count of the media account is {count}.", totalAssets);
 
+            var resourceFilter = GetAssetResourceFilter(_options.ResourceFilter,
+                                                        _options.CreationTimeStart,
+                                                        _options.CreationTimeEnd);
+
             var orderBy = "properties/created";
             var assets = account.GetMediaAssets()
-                .GetAllAsync(_options.ResourceFilter, orderby: orderBy, cancellationToken: cancellationToken);
+                .GetAllAsync(resourceFilter, orderby: orderBy, cancellationToken: cancellationToken);
 
             List<MediaAssetResource>? filteredList = null;
 
-            if (_options.ResourceFilter != null)
+            if (resourceFilter != null)
             {
                 // When a filter is used, it usually inlcude a small list of assets,
                 // The accurate total count of asset can be extracted in advance without much perf hit.

--- a/ams/BaseMigrator.cs
+++ b/ams/BaseMigrator.cs
@@ -127,5 +127,41 @@ namespace AMSMigrate.Ams
                 }
             });
         }
+
+        protected string? GetAssetResourceFilter(string? filterOption, DateTimeOffset? creationTimeStart, DateTimeOffset? creationTimeEnd)
+        {
+            var resourceFilter = filterOption;
+
+            if (creationTimeStart != null || creationTimeEnd != null)
+            {
+                // When --creation-time-start or --create-time-end option is set, 
+                // Convert it to the filter format and combine with the current filter option's settings.
+
+                var startTime = creationTimeStart?.ToString("yyyy-MM-ddThh:mm:ssZ");
+                var endTime = creationTimeEnd?.ToString("yyyy-MM-ddThh:mm:ssZ");
+
+                if (startTime != null)
+                {
+                    if (resourceFilter != null)
+                    {
+                        resourceFilter += " and ";
+                    }
+
+                    resourceFilter += $"properties/created ge {startTime}";
+                }
+
+                if (endTime != null)
+                {
+                    if (resourceFilter != null)
+                    {
+                        resourceFilter += " and ";
+                    }
+
+                    resourceFilter += $"properties/created le {endTime}";
+                }
+            }
+
+            return resourceFilter;
+        }
     }
 }

--- a/contracts/AnalysisOptions.cs
+++ b/contracts/AnalysisOptions.cs
@@ -7,5 +7,5 @@
         Report
     }
 
-    public record AnalysisOptions(string AccountName, string? ResourceFilter, AnalysisType AnalysisType, int BatchSize);
+    public record AnalysisOptions(string AccountName, DateTimeOffset? CreationTimeStart, DateTimeOffset? CreationTimeEnd, string? ResourceFilter, AnalysisType AnalysisType, int BatchSize);
 }

--- a/contracts/AssetOptions.cs
+++ b/contracts/AssetOptions.cs
@@ -5,6 +5,8 @@
         string StoragePath,        
         Packager Packager,
         string PathTemplate,
+        DateTimeOffset? CreationTimeStart,
+        DateTimeOffset? CreationTimeEnd,
         string? ResourceFilter,
         string WorkingDirectory,
         bool CopyNonStreamable,


### PR DESCRIPTION
…"analyze" and "assets"

Description:

    For "assets" and "analyze" command, below two options are common and useful to select a list of input assets based on the creation time,

        --creation-time-start (-cs) is the earliest creation time of the selected input assets.
        --creation-time-end (-ce) is the latest creation time of the selected input assets.

    Make the -resource-filter to cover less common scenarios.