### PR TITLE
Improvement for the options of "assets" and "storage"

### DIFF
--- a/AssetOptionsBinder.cs
+++ b/AssetOptionsBinder.cs
@@ -28,10 +28,15 @@ For Azure specify the storage account name or the URL <https://accountname.blob.
 
         private readonly Option<string?> _pathTemplate = new (
             aliases: new[] { "--path-template", "-t" },
-            () => "${AssetId}/",
+            () => "ams-migration-output/${ContainerName}/",
             description: @"Path template to determine the final path in the storage where files are uploaded.
-Can use ${AssetName} ${AssetId} ${ContainerName} or ${LocatorId}.
-e.g., videos/${AssetName} will upload to a container named 'videos' with path beginning with the asset name.")
+Below are valid keyword that can be put in the path template:
+    ${AssetName}     for input asset's name.
+    ${AssetId}       for the Guid of the assetId.
+    ${ContainerName} for the container name of the input asset.
+    ${AlternateId}   for the alternative id of the input asset, use AssetName if AlternateId is not set.
+    ${LocatorId}     for the first locatorId of the input asset, or an empty GUID if locatorId is not set.
+e.g., ams-migration-output/${AssetName}/ will upload to a container named 'ams-migration-output' with path beginning with the input asset name.")
         {
             Arity = ArgumentArity.ZeroOrOne
         };

--- a/ams/StorageMigrator.cs
+++ b/ams/StorageMigrator.cs
@@ -46,7 +46,7 @@ namespace AMSMigrate.Ams
             var writer = channel.Writer;
 
             var containers = storageClient.GetBlobContainersAsync(
-                               prefix: _storageOptions.Prefix ?? "asset-", cancellationToken: cancellationToken);
+                               prefix: _storageOptions.Prefix, cancellationToken: cancellationToken);
 
             List<BlobContainerItem>? filteredList = null;
 
@@ -126,11 +126,18 @@ namespace AMSMigrate.Ams
             {
                 if (result.Status == MigrationStatus.Completed)
                 {
-                    _logger.LogDebug("Asset: {name} has already been migrated.", container.Name);
+                    _logger.LogDebug("Container: {name} has already been migrated.", container.Name);
                     result.Status = MigrationStatus.AlreadyMigrated;
                     return result;
                 }
             }
+
+            if (result.AssetType == AssetMigrationResult.AssetType_DmtGenerated)
+            {
+                _logger.LogDebug("Container: {name} holds the migrated data.", container.Name);
+                result.Status = MigrationStatus.Skipped;
+                return result;
+            }            
 
             var assetDetails = await containerClient.GetDetailsAsync(_logger, cancellationToken);            
 

--- a/ams/TemplateMapper.cs
+++ b/ams/TemplateMapper.cs
@@ -128,7 +128,7 @@ namespace AMSMigrate.Ams
                     case "ContainerName":
                         return asset.Data.Container;
                     case "AlternateId":
-                        return asset.Data.AlternateId;
+                        return asset.Data.AlternateId ?? asset.Data.Name;
                     case "LocatorId":
                         var locatorId = GetLocatorIdAsync(asset).Result;
                         return locatorId;


### PR DESCRIPTION
Description:

    Update the description for path-template option with clear definitions of different template keywords,
    Set default value for "asset" command.
    Update TemplateMapper so that when AlternativeId is not set, use the AssetName.

    For "storage" command, get rid of the default "asset-" prefix if prefix is not set,
    with RestV3 API, customer can choose their own container name for an asset, so an asset's container may not always have asset- as its fix.

    If the container is in the input asset list and it is used for the migrated data,
    don't treat it as input asset in "storage" command, report as Skipped and exit the operation for this asset as quick as possible.