### PR TITLE
Handle media services with 0 assets

### DIFF
--- a/ams/BaseMigrator.cs
+++ b/ams/BaseMigrator.cs
@@ -89,7 +89,7 @@ namespace AMSMigrate.Ams
                 cancellationToken: cancellationToken);
             var metric = queryResult.Metrics[0];
             var series = metric.TimeSeries[metric.TimeSeries.Count - 1];
-            var totalAssets = series.Values.Last(v => v.Average != null).Average ?? 0.0;
+            var totalAssets = series.Values.LastOrDefault(v => v.Average != null)?.Average ?? 0.0;
             return totalAssets;
         }
 


### PR DESCRIPTION
Last() on MetricsQueryResult.Metrics.TimeSeries will throw exception when there is zero asset.