### PR TITLE
Fix the issue that "storage" command throw exception

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -111,8 +111,6 @@ amsmigrate storage -s <subscription id> -g <resource group> -n <source storage a
                 .AddSingleton(console)
                 .AddSingleton<IMigrationTracker<BlobContainerClient, AssetMigrationResult>, AssetMigrationTracker>()
                 .AddSingleton<TemplateMapper>()
-                .AddSingleton<TransMuxer>()
-                .AddSingleton<TransformFactory>()
                 .AddSingleton<AzureResourceProvider>()
                 .AddLogging(builder =>
                 {
@@ -170,7 +168,7 @@ amsmigrate storage -s <subscription id> -g <resource group> -n <source storage a
             using var listener = new TextWriterTraceListener(globalOptions.LogFile);
             var collection = SetupServices(globalOptions, listener)
                 .AddSingleton(assetOptions)
-                .AddSingleton<PackagerFactory>()
+                .AddSingleton<TransformFactory<AssetOptions>>()
                 .AddSingleton<AssetMigrator>();
             var provider = collection.BuildServiceProvider();
             var logger = provider.GetRequiredService<ILogger<Program>>();
@@ -187,7 +185,7 @@ amsmigrate storage -s <subscription id> -g <resource group> -n <source storage a
             using var listener = new TextWriterTraceListener(globalOptions.LogFile);
             var collection = SetupServices(globalOptions, listener)
                 .AddSingleton(storageOptions)
-                .AddSingleton<PackagerFactory>()
+                .AddSingleton<TransformFactory<StorageOptions>>()
                 .AddSingleton<StorageMigrator>();
             var provider = collection.BuildServiceProvider();
             var logger = provider.GetRequiredService<ILogger<Program>>();

--- a/ams/AssetMigrator.cs
+++ b/ams/AssetMigrator.cs
@@ -17,7 +17,7 @@ namespace AMSMigrate.Ams
     internal class AssetMigrator : BaseMigrator
     {
         private readonly ILogger _logger;
-        private readonly TransformFactory _transformFactory;
+        private readonly TransformFactory<AssetOptions> _transformFactory;
         private readonly AssetOptions _options;
         private readonly IMigrationTracker<BlobContainerClient, AssetMigrationResult> _tracker;
 
@@ -28,7 +28,7 @@ namespace AMSMigrate.Ams
             TokenCredential credential,
             IMigrationTracker<BlobContainerClient, AssetMigrationResult> tracker,
             ILogger<AssetMigrator> logger,
-            TransformFactory transformFactory):
+            TransformFactory<AssetOptions> transformFactory):
             base(globalOptions, console, credential)
         {
             _options = assetOptions;

--- a/ams/StorageMigrator.cs
+++ b/ams/StorageMigrator.cs
@@ -14,7 +14,7 @@ namespace AMSMigrate.Ams
     internal class StorageMigrator : BaseMigrator
     {
         private readonly ILogger _logger;
-        private readonly TransformFactory _transformFactory;
+        private readonly TransformFactory<StorageOptions> _transformFactory;
         private readonly StorageOptions _storageOptions;
         private readonly IMigrationTracker<BlobContainerClient, AssetMigrationResult> _tracker;
 
@@ -24,7 +24,7 @@ namespace AMSMigrate.Ams
             IAnsiConsole console,
             IMigrationTracker<BlobContainerClient, AssetMigrationResult> tracker,
             TokenCredential credentials,
-            TransformFactory transformFactory,
+            TransformFactory<StorageOptions> transformFactory,
             ILogger<StorageMigrator> logger) :
             base(options, console, credentials)
         {

--- a/azure/AzureProvider.cs
+++ b/azure/AzureProvider.cs
@@ -17,8 +17,8 @@ namespace AMSMigrate.Azure
             _loggerFactory = loggerFactory;
         }
 
-        public IFileUploader GetStorageProvider(AssetOptions assetOptions) 
-            => new AzureStorageUploader(assetOptions, _credentials, _loggerFactory.CreateLogger<AzureStorageUploader>());
+        public IFileUploader GetStorageProvider(MigratorOptions migratorOptions) 
+            => new AzureStorageUploader(migratorOptions, _credentials, _loggerFactory.CreateLogger<AzureStorageUploader>());
 
         public ISecretUploader GetSecretProvider(KeyOptions keyOptions) 
             => new KeyVaultUploader(keyOptions, _credentials, _loggerFactory.CreateLogger<KeyVaultUploader>());

--- a/azure/AzureStorageUploader.cs
+++ b/azure/AzureStorageUploader.cs
@@ -11,12 +11,12 @@ namespace AMSMigrate.Azure
 {
     internal class AzureStorageUploader : IFileUploader
     {
-        private readonly AssetOptions _options;
+        private readonly MigratorOptions _options;
         private readonly ILogger _logger;
         private readonly BlobServiceClient _blobServiceClient;
 
         public AzureStorageUploader(
-            AssetOptions options,
+            MigratorOptions options,
             TokenCredential credential, 
             ILogger<AzureStorageUploader> logger)
         {

--- a/contracts/AssetOptions.cs
+++ b/contracts/AssetOptions.cs
@@ -15,5 +15,18 @@
         bool SkipMigrated,
         bool DeleteMigrated,
         int SegmentDuration,
-        int BatchSize);
+        int BatchSize)
+        : MigratorOptions(
+            AccountName,
+            StoragePath,
+            Packager,
+            PathTemplate,
+            WorkingDirectory,
+            CopyNonStreamable,
+            OverWrite,
+            MarkCompleted,
+            SkipMigrated, 
+            DeleteMigrated,
+            SegmentDuration,
+            BatchSize);
 }

--- a/contracts/ICloudProvider.cs
+++ b/contracts/ICloudProvider.cs
@@ -3,7 +3,7 @@ namespace AMSMigrate.Contracts
 {
     interface ICloudProvider
     {
-        IFileUploader GetStorageProvider(AssetOptions assetOptions);
+        IFileUploader GetStorageProvider(MigratorOptions migratorOptions);
 
         ISecretUploader GetSecretProvider(KeyOptions keyOptions);
     }

--- a/contracts/MigratorOptions.cs
+++ b/contracts/MigratorOptions.cs
@@ -1,0 +1,19 @@
+﻿namespace AMSMigrate.Contracts
+{
+    /// <summary>
+    /// It holds the common options for migrating commands, such as "assets" and "storage".
+    /// </summary>
+    public record MigratorOptions(
+        string AccountName,
+        string StoragePath,        
+        Packager Packager,
+        string PathTemplate,
+        string WorkingDirectory,
+        bool CopyNonStreamable,
+        bool OverWrite,
+        bool MarkCompleted,
+        bool SkipMigrated,
+        bool DeleteMigrated,
+        int SegmentDuration,
+        int BatchSize);
+}

--- a/contracts/StorageOptions.cs
+++ b/contracts/StorageOptions.cs
@@ -13,5 +13,18 @@
         bool SkipMigrated,
         bool DeleteMigrated,
         int SegmentDuration,
-        int BatchSize);
+        int BatchSize)
+        : MigratorOptions(
+            AccountName,
+            StoragePath,
+            Packager,
+            PathTemplate,
+            WorkingDirectory,
+            CopyNonStreamable,
+            OverWrite,
+            MarkCompleted,
+            SkipMigrated,
+            DeleteMigrated,
+            SegmentDuration,
+            BatchSize);
 }

--- a/local/LocalFileProvider.cs
+++ b/local/LocalFileProvider.cs
@@ -17,7 +17,7 @@ namespace AMSMigrate.Local
             throw new NotImplementedException();
         }
 
-        public IFileUploader GetStorageProvider(AssetOptions assetOptions)
+        public IFileUploader GetStorageProvider(MigratorOptions assetOptions)
         {
             return new LocalFileUploader(assetOptions, _loggerFactory.CreateLogger<LocalFileUploader>());
         }

--- a/local/LocalFileUploader.cs
+++ b/local/LocalFileUploader.cs
@@ -7,10 +7,10 @@ namespace AMSMigrate.Local
 {
     internal class LocalFileUploader : IFileUploader
     {
-        private readonly AssetOptions _assetOptions;
+        private readonly MigratorOptions _assetOptions;
         private readonly ILogger _logger;
 
-        public LocalFileUploader(AssetOptions options, ILogger<LocalFileUploader> logger)
+        public LocalFileUploader(MigratorOptions options, ILogger<LocalFileUploader> logger)
         {
             _assetOptions = options;
             _logger = logger;

--- a/transform/PackageTransform.cs
+++ b/transform/PackageTransform.cs
@@ -5,13 +5,13 @@ using Microsoft.Extensions.Logging;
 
 namespace AMSMigrate.Transform
 {
-    internal class PackageTransform : StorageTransform
+    internal class PackageTransform<TOptions> : StorageTransform
     {
         private readonly PackagerFactory _packagerFactory;
 
         public PackageTransform(
-            AssetOptions options,
-            ILogger<PackageTransform> logger,
+            MigratorOptions options,
+            ILogger<PackageTransform<TOptions>> logger,
             TemplateMapper templateMapper,
             IFileUploader uploader,
             PackagerFactory factory)

--- a/transform/PackagerFactory.cs
+++ b/transform/PackagerFactory.cs
@@ -5,15 +5,15 @@ namespace AMSMigrate.Transform
 {
     internal class PackagerFactory
     {
-        private readonly AssetOptions _options;
+        private readonly MigratorOptions _options;
         private readonly ILoggerFactory _loggerFactory;
         private readonly TransMuxer _transMuxer;
 
-        public PackagerFactory(ILoggerFactory factory, AssetOptions options, TransMuxer transMuxer) 
-        {
-            _transMuxer = transMuxer;
-            _options = options;
+        public PackagerFactory(ILoggerFactory factory, MigratorOptions options) 
+        {          
             _loggerFactory = factory;
+            _options = options;
+            _transMuxer = new TransMuxer(options, _loggerFactory.CreateLogger<TransMuxer>());
         }
 
         public BasePackager GetPackager(AssetDetails details, CancellationToken cancellationToken)

--- a/transform/StorageTransform.cs
+++ b/transform/StorageTransform.cs
@@ -4,8 +4,6 @@ using AMSMigrate.Contracts;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Specialized;
 using Microsoft.Extensions.Logging;
-using System.ComponentModel;
-using System.Reflection.Metadata;
 
 namespace AMSMigrate.Transform
 {
@@ -13,13 +11,13 @@ namespace AMSMigrate.Transform
 
     internal abstract class StorageTransform : ITransform<AssetDetails, AssetMigrationResult>
     {
-        protected readonly AssetOptions _options;
+        protected readonly MigratorOptions _options;
         private readonly TemplateMapper _templateMapper;
         protected readonly ILogger _logger;
         protected readonly IFileUploader _fileUploader;     
 
         public StorageTransform(
-            AssetOptions options,
+            MigratorOptions options,
             TemplateMapper templateMapper,
             IFileUploader fileUploader,
             ILogger logger)

--- a/transform/TransMuxer.cs
+++ b/transform/TransMuxer.cs
@@ -11,12 +11,12 @@ namespace AMSMigrate.Transform
     {
         static readonly StreamingPolicyStreamingProtocol Protocol = StreamingPolicyStreamingProtocol.Hls;
 
-        private readonly AssetOptions _options;
+        private readonly MigratorOptions _options;
         private readonly ILogger _logger;
         private string? _hostName = null;
 
         public TransMuxer(
-            AssetOptions options,
+            MigratorOptions options,
             ILogger<TransMuxer> logger)
         {
             _logger = logger;

--- a/transform/UploadTransform.cs
+++ b/transform/UploadTransform.cs
@@ -8,7 +8,7 @@ namespace AMSMigrate.Transform
     internal class UploadTransform : StorageTransform
     {
         public UploadTransform(
-            AssetOptions options,
+            MigratorOptions options,
             IFileUploader uploader,
             ILogger<UploadTransform> logger,
             TemplateMapper templateMapper) :


### PR DESCRIPTION
Description:

   After command "storage" and "assets" have their own command line options, the AssetOptins type is not available for "storage" command,
   The TransformFactory, PackagerFactory internally still assume to work with AssetOptions.

   This change adds a new base record MigratorOptions, which is the base for AssetOptions and StorageOptins,
   PackagerFactory, TransMuxer, Uploader classes would work with MigratorOption.

   Class TransformFactory takes use of generic type for Options, the DI of those types in Top Level is updated
   so that for "assets" cmd, it will generate a singleton instance of "TransformFactory_AssetsOptions",
   for "storage" comamnd, it will generate a singleton instance of "TransformFactory_StorageOptions".

   PackagerFactory and TransMuxer can be generated by TransformFactory.

   Both "assets" and "storage" command work as expected with the change.