### PR TITLE
Remove --delete-migrated and --mark-completion option from "assets" a…

### DIFF
--- a/AssetOptionsBinder.cs
+++ b/AssetOptionsBinder.cs
@@ -83,11 +83,6 @@ Visit https://learn.microsoft.com/en-us/azure/media-services/latest/filter-order
             IsRequired = false
         };
 
-        private readonly Option<bool> _markComplete = new(
-            aliases: new[] { "-m", "--mark-complete" },
-            () => true,
-            description: @"Mark completed assets by writing metadata on the container");
-
         private readonly Option<bool> _skipMigrated = new(
             aliases: new[] { "--skip-migrated" },
             () => true,
@@ -102,11 +97,6 @@ Visit https://learn.microsoft.com/en-us/azure/media-services/latest/filter-order
             aliases: new[] { "-y", "--overwrite" },
             () => true,
             description: @"Overwrite the files in the destination.");
-
-        private readonly Option<bool> _deleteMigrated = new(
-            aliases: new[] { "--delete-migrated" },
-            () => false,
-            description: @"Delete the asset after migration.");
 
         const int DefaultBatchSize = 1;
         private readonly Option<int> _batchSize = new(
@@ -150,9 +140,7 @@ Visit https://learn.microsoft.com/en-us/azure/media-services/latest/filter-order
             command.AddOption(_creationTimeEnd);
             command.AddOption(_filter);
             command.AddOption(_overwrite);
-            command.AddOption(_markComplete);
             command.AddOption(_skipMigrated);
-            command.AddOption(_deleteMigrated);
             command.AddOption(_packagerType);
             command.AddOption(_workingDirectory);
             command.AddOption(_copyNonStreamable);
@@ -175,9 +163,7 @@ Visit https://learn.microsoft.com/en-us/azure/media-services/latest/filter-order
                 workingDirectory,
                 bindingContext.ParseResult.GetValueForOption(_copyNonStreamable),
                 bindingContext.ParseResult.GetValueForOption(_overwrite),
-                bindingContext.ParseResult.GetValueForOption(_markComplete),
                 bindingContext.ParseResult.GetValueForOption(_skipMigrated),
-                bindingContext.ParseResult.GetValueForOption(_deleteMigrated),
                 SegmentDurationInSeconds,
                 bindingContext.ParseResult.GetValueForOption(_batchSize)
             );

--- a/StorageOptionsBinder.cs
+++ b/StorageOptionsBinder.cs
@@ -60,11 +60,6 @@ e.g., ams-migration-output/${ContainerName} will upload to a container named 'am
             IsRequired = false
         };
 
-        private readonly Option<bool> _markComplete = new(
-            aliases: new[] { "-m", "--mark-complete" },
-            () => true,
-            description: @"Mark completed assets by writing metadata on the container");
-
         private readonly Option<bool> _skipMigrated = new(
             aliases: new[] { "--skip-migrated" },
             () => true,
@@ -79,11 +74,6 @@ e.g., ams-migration-output/${ContainerName} will upload to a container named 'am
             aliases: new[] { "-y", "--overwrite" },
             () => true,
             description: @"Overwrite the files in the destination.");
-
-        private readonly Option<bool> _deleteMigrated = new(
-            aliases: new[] { "--delete-migrated" },
-            () => false,
-            description: @"Delete the container after migration.");
 
         const int DefaultBatchSize = 1;
         private readonly Option<int> _batchSize = new(
@@ -125,9 +115,7 @@ e.g., ams-migration-output/${ContainerName} will upload to a container named 'am
             command.AddOption(_pathTemplate);
             command.AddOption(_prefix);
             command.AddOption(_overwrite);
-            command.AddOption(_markComplete);
             command.AddOption(_skipMigrated);
-            command.AddOption(_deleteMigrated);
             command.AddOption(_packagerType);
             command.AddOption(_workingDirectory);
             command.AddOption(_copyNonStreamable);
@@ -148,9 +136,7 @@ e.g., ams-migration-output/${ContainerName} will upload to a container named 'am
                 workingDirectory,
                 bindingContext.ParseResult.GetValueForOption(_copyNonStreamable),
                 bindingContext.ParseResult.GetValueForOption(_overwrite),
-                bindingContext.ParseResult.GetValueForOption(_markComplete),
                 bindingContext.ParseResult.GetValueForOption(_skipMigrated),
-                bindingContext.ParseResult.GetValueForOption(_deleteMigrated),
                 SegmentDurationInSeconds,
                 bindingContext.ParseResult.GetValueForOption(_batchSize)
             );

--- a/ams/StorageMigrator.cs
+++ b/ams/StorageMigrator.cs
@@ -106,8 +106,7 @@ namespace AMSMigrate.Ams
                 new BarChartItem("AlreadyMigrated", value.Migrated, Color.Green),
                 new BarChartItem("Skipped", value.Skipped, Color.Grey),
                 new BarChartItem("Successful", value.Successful, Color.Green),
-                new BarChartItem("Failed", value.Failed, Color.Red),
-                new BarChartItem("Deleted", value.Deleted, Color.Orange3)
+                new BarChartItem("Failed", value.Failed, Color.Red)
             };
         }
 
@@ -209,15 +208,8 @@ namespace AMSMigrate.Ams
                 _logger.LogWarning("Skipping container {name} because it is not in a supported format!!!", container.Name);
             }
             
-            if (_storageOptions.MarkCompleted)
-            {
-                await _tracker.UpdateMigrationStatus(containerClient, result, cancellationToken);
-            }
-            if (result.Status == MigrationStatus.Completed && _storageOptions.DeleteMigrated)
-            {
-                _logger.LogWarning("Deleting container {name} after migration", container.Name);
-                await storageClient.DeleteBlobContainerAsync(container.Name, cancellationToken: cancellationToken);
-            }
+            await _tracker.UpdateMigrationStatus(containerClient, result, cancellationToken);
+
             return result;
         }
         
@@ -241,10 +233,6 @@ namespace AMSMigrate.Ams
                     {
                         case MigrationStatus.Completed:
                             ++stats.Successful;
-                            if (_storageOptions.DeleteMigrated)
-                            {
-                                ++stats.Deleted;
-                            }
                             break;
                         case MigrationStatus.Skipped:
                             ++stats.Skipped;
@@ -276,8 +264,8 @@ namespace AMSMigrate.Ams
                 .AddRow("[green]Already Migrated[/]", $"[green]{stats.Migrated}[/]")
                 .AddRow("[gray]Skipped[/]", $"[gray]{stats.Skipped}[/]")
                 .AddRow("[green]Successful[/]", $"[green]{stats.Successful}[/]")
-                .AddRow("[red]Failed[/]", $"[red]{stats.Failed}[/]")
-                .AddRow("[orange3]Deleted[/]", $"[orange3]{stats.Deleted}[/]");
+                .AddRow("[red]Failed[/]", $"[red]{stats.Failed}[/]");
+
             _console.Write(table);
         }
     }

--- a/contracts/AssetOptions.cs
+++ b/contracts/AssetOptions.cs
@@ -11,9 +11,7 @@
         string WorkingDirectory,
         bool CopyNonStreamable,
         bool OverWrite,
-        bool MarkCompleted,
         bool SkipMigrated,
-        bool DeleteMigrated,
         int SegmentDuration,
         int BatchSize)
         : MigratorOptions(
@@ -24,9 +22,7 @@
             WorkingDirectory,
             CopyNonStreamable,
             OverWrite,
-            MarkCompleted,
             SkipMigrated, 
-            DeleteMigrated,
             SegmentDuration,
             BatchSize);
 }

--- a/contracts/MigratorOptions.cs
+++ b/contracts/MigratorOptions.cs
@@ -11,9 +11,7 @@
         string WorkingDirectory,
         bool CopyNonStreamable,
         bool OverWrite,
-        bool MarkCompleted,
         bool SkipMigrated,
-        bool DeleteMigrated,
         int SegmentDuration,
         int BatchSize);
 }

--- a/contracts/StorageOptions.cs
+++ b/contracts/StorageOptions.cs
@@ -9,9 +9,7 @@
         string WorkingDirectory,
         bool CopyNonStreamable,
         bool OverWrite,
-        bool MarkCompleted,
         bool SkipMigrated,
-        bool DeleteMigrated,
         int SegmentDuration,
         int BatchSize)
         : MigratorOptions(
@@ -22,9 +20,7 @@
             WorkingDirectory,
             CopyNonStreamable,
             OverWrite,
-            MarkCompleted,
             SkipMigrated,
-            DeleteMigrated,
             SegmentDuration,
             BatchSize);
 }


### PR DESCRIPTION
…nd "storage" command

Description:

   This change removes --delete-migrated and --mark-completion options in "assets" and "storage" command.

   A new command "cleanup" will be added later for the asset-deletion work.

   We will use the metadata settings on both input and output contaners to track the status.

   Option --mark-completion is set to true by default, no need to give customer an option to set it to false.