### PR TITLE
Hide {LocatorId} from the output path template for "assets" command

### DIFF
--- a/AssetOptionsBinder.cs
+++ b/AssetOptionsBinder.cs
@@ -35,7 +35,6 @@ Below are valid keyword that can be put in the path template:
     ${AssetId}       for the Guid of the assetId.
     ${ContainerName} for the container name of the input asset.
     ${AlternateId}   for the alternative id of the input asset, use AssetName if AlternateId is not set.
-    ${LocatorId}     for the first locatorId of the input asset, or an empty GUID if locatorId is not set.
 e.g., ams-migration-output/${AssetName}/ will upload to a container named 'ams-migration-output' with path beginning with the input asset name.")
         {
             Arity = ArgumentArity.ZeroOrOne

--- a/ams/TemplateMapper.cs
+++ b/ams/TemplateMapper.cs
@@ -30,7 +30,7 @@ namespace AMSMigrate.Ams
                     "AssetName",
                     "AlternateId",
                     "ContainerName",
-                    "LocatorId",
+                    // "LocatorId",
                 }
             },
             {
@@ -129,9 +129,9 @@ namespace AMSMigrate.Ams
                         return asset.Data.Container;
                     case "AlternateId":
                         return asset.Data.AlternateId ?? asset.Data.Name;
-                    case "LocatorId":
-                        var locatorId = GetLocatorIdAsync(asset).Result;
-                        return locatorId;
+                    // case "LocatorId":
+                    //    var locatorId = GetLocatorIdAsync(asset).Result;
+                    //    return locatorId;
                 }
                 return null;
             });


### PR DESCRIPTION
Description:

   Comment out the code for LocatorId keyword in the output path template,
   This can be re-enabled later if customers ask for it.