### PR TITLE
Ensure the source media files are not directly copied over to destina…

### DIFF
--- a/ams/AssetMigrator.cs
+++ b/ams/AssetMigrator.cs
@@ -212,7 +212,7 @@ namespace AMSMigrate.Ams
                                     result.Status = transformResult.Status;
                                     result.OutputPath = transformResult.OutputPath;
 
-                                    if (result.Status == MigrationStatus.Failed)
+                                    if (result.Status != MigrationStatus.Skipped)
                                     {
                                         break;
                                     }

--- a/ams/StorageMigrator.cs
+++ b/ams/StorageMigrator.cs
@@ -176,7 +176,7 @@ namespace AMSMigrate.Ams
                             result.Status = transformResult.Status;
                             result.OutputPath = transformResult.OutputPath;
 
-                            if (result.Status == MigrationStatus.Failed)
+                            if (result.Status != MigrationStatus.Skipped)
                             {
                                 break;
                             }

--- a/transform/PackageTransform.cs
+++ b/transform/PackageTransform.cs
@@ -150,7 +150,10 @@ namespace AMSMigrate.Transform
                 Directory.Delete(workingDirectory, true);
             }
 
-            return $"{outputPath.Prefix}{Path.GetFileNameWithoutExtension(manifest.FileName)}";
+            // Mark the output container appropriately so that it won't be used as an input asset in new run.
+            await UpdateOutputStatus(outputPath.Container, cancellationToken);
+
+            return outputPath.Prefix;
         }
 
         private UploadPipe CreateUpload(string filePath, UploadHelper helper)

--- a/transform/StorageTransform.cs
+++ b/transform/StorageTransform.cs
@@ -42,12 +42,6 @@ namespace AMSMigrate.Transform
             var result = new AssetMigrationResult();
 
             _logger.LogTrace("Asset {asset} is in format: {format}.", details.AssetName, details.Manifest?.Format);
-            if (details.Manifest != null && details.Manifest.IsLive)
-            {
-                _logger.LogWarning("Skipping asset {asset} which is from a running live event. Rerun the migration after the live event is stopped.", details.AssetName);
-                result.Status = MigrationStatus.Skipped;
-                return result;
-            }
 
             if (IsSupported(details))
             {
@@ -61,6 +55,16 @@ namespace AMSMigrate.Transform
                 {
                     result.Status = MigrationStatus.Failed;
                 }
+            }
+            else
+            {
+                var format = details.Manifest != null ? details.Manifest.Format : "non_ism";
+                _logger.LogInformation("The asset {asset} with format {format} is not supported by transform {transform} in current version, try next transform...", 
+                    details.AssetName,
+                    format,
+                    this.GetType().Name);
+
+                result.Status = MigrationStatus.Skipped;
             }
 
             return result;


### PR DESCRIPTION
…tion if it is handled by packager

Description:

  The TranformFactory might contain more transforms,  PackagerTransform and UploadTransform.

  But usually only one transform is needed for a specific source asset.

  When the source asset contains .ism, it is supposed to be handled by the PackagerTransform.
  When the source asset doesn't have .ism, it is UploadTransform's job to copy over media files.

  Each Transform instance has its own logic to determine what type of source asset can be supported by this transform.

  If a previous transform doesn't support such input asset, it returns status as Skipped,
  The next transform is invoked only when previous transform reports Skipped.

  Make sure the outputPath reported by all these transforms follow the same spec, which points to the destination folder only.