### PR TITLE
Use Paralle.ForEachAsync to improve parallelism.

### DIFF
--- a/ams/AssetStats.cs
+++ b/ams/AssetStats.cs
@@ -1,0 +1,71 @@
+﻿using AMSMigrate.Contracts;
+using AMSMigrate.Transform;
+
+namespace AMSMigrate.Ams
+{
+    record class AssetStats
+    {
+        private int _streamable;
+        private int _noLocators;
+        private int _skipped;
+        private int _failed;
+        private int _total;
+        private int _migrated;
+        private int _successful;
+
+        public int Total => _total;
+
+        public int Streamable => _streamable;
+
+        public int Migrated => _migrated;
+
+        public int Successful => _successful;
+
+        public int Failed => _failed;
+
+        public int Skipped => _skipped;
+
+        public int NoLocators => _noLocators;
+
+        public void Update(AnalysisResult result)
+        {
+            Update(result.Status);
+            if (result.IsStreamable)
+            {
+                Interlocked.Increment(ref _streamable);
+            }
+
+            if (result.Locators == 0)
+            {
+                Interlocked.Increment(ref _noLocators);
+            }
+        }
+
+        public void Updated(AssetMigrationResult result)
+        {
+            Update(result.Status);
+        }
+
+        public void Update(MigrationResult result)
+        {
+            Interlocked.Increment(ref _total);
+            switch (result.Status)
+            {
+                case MigrationStatus.Completed:
+                    Interlocked.Increment(ref _successful);
+                    break;
+                case MigrationStatus.Skipped:
+                case MigrationStatus.NotMigrated:
+                    Interlocked.Increment(ref _skipped);
+                    break;
+                case MigrationStatus.AlreadyMigrated:
+                    Interlocked.Increment(ref _migrated);
+                    break;
+                case MigrationStatus.Failed:
+                default:
+                    Interlocked.Increment(ref _failed);
+                    break;
+            }
+        }
+    }
+}

--- a/ams/ReportGenerator.cs
+++ b/ams/ReportGenerator.cs
@@ -65,9 +65,9 @@ namespace AMSMigrate.Ams
 </html>");
         }
 
-        public void WriteRows(AnalysisResult[] results)
+        public void WriteRow(AnalysisResult result)
         {
-            foreach (var result in results)
+            lock(this)
             {
                 _writer.Write($"<tr><td>{result.AssetName}</td><td>{result.AssetType}</td><td>{result.Status}</td><td>");
                 if (result.OutputPath != null)

--- a/azure/AzureStorageUploader.cs
+++ b/azure/AzureStorageUploader.cs
@@ -45,6 +45,7 @@ namespace AMSMigrate.Azure
             string containerName,
             string fileName,
             Stream content,
+            Headers headers,
             IProgress<long> progress,
             CancellationToken cancellationToken = default)
         {
@@ -57,6 +58,10 @@ namespace AMSMigrate.Azure
             var options = new BlobUploadOptions
             {
                 ProgressHandler = progress,
+                HttpHeaders = new BlobHttpHeaders
+                {
+                    ContentType = headers.ContentType
+                },
                 Conditions = new BlobRequestConditions
                 {
                     IfNoneMatch = _options.OverWrite ? null : ETag.All

--- a/contracts/IFileUploader.cs
+++ b/contracts/IFileUploader.cs
@@ -1,6 +1,8 @@
 ﻿
 namespace AMSMigrate.Contracts
 {
+    public record Headers(string? ContentType);
+
     public interface IFileUploader
     {
         Uri GetDestinationUri(string container, string fileName);
@@ -9,6 +11,7 @@ namespace AMSMigrate.Contracts
             string container,
             string fileName,
             Stream content,
+            Headers headers,
             IProgress<long> progress,
             CancellationToken cancellationToken);
 

--- a/local/LocalFileUploader.cs
+++ b/local/LocalFileUploader.cs
@@ -20,7 +20,7 @@ namespace AMSMigrate.Local
             return new Uri(Path.Combine(_assetOptions.StoragePath, container, fileName));
         }
 
-        public async Task UploadAsync(string container, string fileName, Stream content, IProgress<long> progress, CancellationToken cancellationToken)
+        public async Task UploadAsync(string container, string fileName, Stream content, Headers headers, IProgress<long> progress, CancellationToken cancellationToken)
         {
             var subDir = Path.GetDirectoryName(fileName) ?? string.Empty;
             if (subDir[0] == '/' || subDir[0] == '\\')

--- a/pipes/BlobSink.cs
+++ b/pipes/BlobSink.cs
@@ -29,12 +29,14 @@ namespace AMSMigrate.Pipes
         private readonly string _container;
         private readonly string _filename;
         private readonly ILogger _logger;
+        private Headers _headers;
 
-        public UploadSink(IFileUploader uploader, string container, string filename, ILogger logger)
+        public UploadSink(IFileUploader uploader, string container, string filename, Headers headers, ILogger logger)
         {
             _uploader = uploader;
             _container = container;
             _filename = filename;
+            _headers = headers;
             _logger = logger;
         }
 
@@ -46,7 +48,7 @@ namespace AMSMigrate.Pipes
             try
             {
                 var progress = new Progress<long>();
-                await _uploader.UploadAsync(_container, _filename, inputStream, progress, cancellationToken);
+                await _uploader.UploadAsync(_container, _filename, inputStream, _headers, progress, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -58,7 +60,7 @@ namespace AMSMigrate.Pipes
         public async Task UploadAsync(string filename, IProgress<long> progress, CancellationToken cancellationToken)
         {
             using var file = File.OpenRead(filename);
-            await _uploader.UploadAsync(_container, _filename, file, progress, cancellationToken);
+            await _uploader.UploadAsync(_container, _filename, file, _headers, progress, cancellationToken);
         }
     }
 

--- a/pipes/UploadPipe.cs
+++ b/pipes/UploadPipe.cs
@@ -20,10 +20,10 @@ namespace AMSMigrate.Pipes
             _storagePrefix = storagePrefix;
         }
 
-        public async Task UploadAsync(string filename, Stream content, IProgress<long> progress, CancellationToken cancellationToken)
+        public async Task UploadAsync(string filename, Stream content, Headers headers, IProgress<long> progress, CancellationToken cancellationToken)
         {
             var storagePath = _storagePrefix + filename;
-            await _uploader.UploadAsync(_container, storagePath, content, progress, cancellationToken);
+            await _uploader.UploadAsync(_container, storagePath, content, headers, progress, cancellationToken);
         }
     }
 
@@ -33,16 +33,19 @@ namespace AMSMigrate.Pipes
         private readonly UploadHelper _helper;
         private readonly string _filename;
         private readonly IProgress<long> _progress;
+        private readonly Headers _headers;
 
         public UploadPipe(
             string filePath,
             UploadHelper helper,
             ILogger logger,
+            Headers headers,
             IProgress<long> progress) :
             base(filePath, PipeDirection.In)
         {
             _helper = helper;
             _logger = logger;
+            _headers = headers;
             _progress = progress;
             _filename = Path.GetFileName(filePath);
         }
@@ -52,7 +55,7 @@ namespace AMSMigrate.Pipes
             _logger.LogDebug("Starting upload of {Pipe} to storage {blob}", PipePath, _filename);
             await RunAsync(async (stream, token) =>
             {
-                await _helper.UploadAsync(_filename, stream, _progress, token);
+                await _helper.UploadAsync(_filename, stream, _headers, _progress, token);
             }, cancellationToken);
             _logger.LogDebug("Finished upload of {Pipe} to {file}", PipePath, _filename);
         }

--- a/transform/PackageTransform.cs
+++ b/transform/PackageTransform.cs
@@ -160,7 +160,7 @@ namespace AMSMigrate.Transform
         {
             var file = Path.GetFileName(filePath);
             var progress = new Progress<long>(bytes => _logger.LogTrace("Uploaded {bytes} bytes to {name}", bytes, file));
-            return new UploadPipe(filePath, helper, _logger, progress);
+            return new UploadPipe(filePath, helper, _logger, GetHeaders(file), progress);
         }
 
         private async Task UploadFile(string filePath, UploadHelper uploadHelper, CancellationToken cancellationToken)
@@ -169,7 +169,7 @@ namespace AMSMigrate.Transform
             var progress = new Progress<long>(p =>
                 _logger.LogTrace("Uploaded {bytes} bytes to {file}", p, file));
             using var content = File.OpenRead(filePath);
-            await uploadHelper.UploadAsync(Path.GetFileName(file), content, progress, cancellationToken);
+            await uploadHelper.UploadAsync(Path.GetFileName(file), content, GetHeaders(file), progress, cancellationToken);
         }
     }
 }

--- a/transform/StorageTransform.cs
+++ b/transform/StorageTransform.cs
@@ -93,9 +93,9 @@ namespace AMSMigrate.Transform
             {
                 var progress = new Progress<long>(progress =>
                  _logger.LogTrace("Upload progress for {name}: {progress}", blobName, progress));
-
                 var result = await blob.DownloadStreamingAsync(cancellationToken: cancellationToken);
-                await _fileUploader.UploadAsync(container, blobName, result.Value.Content, progress, cancellationToken);
+                var headers = new Headers(result.Value.Details.ContentType);
+                await _fileUploader.UploadAsync(container, blobName, result.Value.Content, headers, progress, cancellationToken);
             }
         }
 
@@ -107,6 +107,20 @@ namespace AMSMigrate.Transform
             {
                 await uploader.UpdateOutputStatus(containerName, cancellationToken);
             }
+        }
+
+        public Headers GetHeaders(string filename)
+        {
+            var contentType = Path.GetExtension(filename) switch
+            {
+                ".m3u8" => "application/vnd.apple.mpegurl",
+                ".mpd" => "application/dash+xml",
+                ".vtt" => "text/vtt",
+                ".json" => "application/json",
+                ".mp4" => "video/mp4",
+                _ => null
+            };
+            return new Headers(contentType);
         }
     }
 }


### PR DESCRIPTION
Set ContentType header when uploading blobs.
Combine multiple declarations to a single AssetStats record.
Fixes #84 and #89 