### PR TITLE
Support migration for the asset with storage-encryption with client key

### DIFF
--- a/ams/AssetMigrator.cs
+++ b/ams/AssetMigrator.cs
@@ -3,7 +3,6 @@ using AMSMigrate.Transform;
 using Azure;
 using Azure.Core;
 using Azure.ResourceManager.Media;
-using Azure.ResourceManager.Media.Models;
 using Azure.Storage.Blobs;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
@@ -144,83 +143,75 @@ namespace AMSMigrate.Ams
                     }
                 }
 
-                if (asset.Data.StorageEncryptionFormat != MediaAssetStorageEncryptionFormat.None)
+                var details = await asset.GetDetailsAsync(_logger, cancellationToken, _options.OutputManifest);
+                var record = new AssetRecord(account, asset, details);
+
+                // AssetType and ManifestName are not supposed to change for a specific input asset,
+                // Set AssetType and manifest from the asset container before doing the actual transforming.
+                if (details.Manifest != null)
                 {
-                    _logger.LogWarning("Asset {name} is encrypted using {format}", asset.Data.Name, asset.Data.StorageEncryptionFormat);
-                    result.AssetType = AssetMigrationResult.AssetType_Encrypted;
+                    result.AssetType = details.Manifest.Format;
+                    result.ManifestName = _options.OutputManifest ?? details.Manifest.FileName?.Replace(".ism", "");
                 }
                 else
                 {
-                    var details = await asset.GetDetailsAsync(_logger, cancellationToken, _options.OutputManifest);
-                    var record = new AssetRecord(account, asset, details);
+                    result.AssetType = AssetMigrationResult.AssetType_NonIsm;
+                }
 
-                    // AssetType and ManifestName are not supposed to change for a specific input asset,
-                    // Set AssetType and manifest from the asset container before doing the actual transforming.
-                    if (details.Manifest != null)
+                if (result.IsSupportedAsset)
+                {
+                    var uploader = _transformFactory.GetUploader(_options);
+                    var (Container, Path) = _transformFactory.TemplateMapper.ExpandAssetTemplate(
+                                                        record.Asset, 
+                                                        _options.PathTemplate);
+
+                    var canUpload = await uploader.CanUploadAsync(
+                                                        Container, 
+                                                        Path, 
+                                                        cancellationToken);
+
+                    if (canUpload)
                     {
-                        result.AssetType = details.Manifest.Format;
-                        result.ManifestName = _options.OutputManifest ?? details.Manifest.FileName?.Replace(".ism", "");
-                    }
-                    else
-                    {
-                        result.AssetType = AssetMigrationResult.AssetType_NonIsm;
-                    }
-
-                    if (result.IsSupportedAsset)
-                    {
-                        var uploader = _transformFactory.GetUploader(_options);
-                        var (Container, Path) = _transformFactory.TemplateMapper.ExpandAssetTemplate(
-                                                            record.Asset, 
-                                                            _options.PathTemplate);
-
-                        var canUpload = await uploader.CanUploadAsync(
-                                                            Container, 
-                                                            Path, 
-                                                            cancellationToken);
-
-                        if (canUpload)
+                        try
                         {
-                            try
+                            foreach (var transform in _transformFactory.GetTransforms(_options))
                             {
-                                foreach (var transform in _transformFactory.GetTransforms(_options))
+                                var transformResult = (AssetMigrationResult)await transform.RunAsync(record, cancellationToken);
+
+                                result.Status = transformResult.Status;
+                                result.OutputPath = transformResult.OutputPath;
+
+                                if (result.Status != MigrationStatus.Skipped)
                                 {
-                                    var transformResult = (AssetMigrationResult)await transform.RunAsync(record, cancellationToken);
-
-                                    result.Status = transformResult.Status;
-                                    result.OutputPath = transformResult.OutputPath;
-
-                                    if (result.Status != MigrationStatus.Skipped)
-                                    {
-                                        break;
-                                    }
+                                    break;
                                 }
                             }
-                            finally
-                            {
-                                await uploader.UploadCleanupAsync(Container, Path, cancellationToken);
-                            }
                         }
-                        else
+                        finally
                         {
-                            //
-                            // Another instance of the tool is working on the output container,
-                            //
-                            result.Status = MigrationStatus.Skipped;
-
-                            _logger.LogWarning("Another tool is working on the container {container} and output path: {output}",
-                                               Container,
-                                               Path);
+                            await uploader.UploadCleanupAsync(Container, Path, cancellationToken);
                         }
                     }
                     else
                     {
-                        // The asset type is not supported in this milestone,
-                        // Mark the status as Skipped for caller to do the statistics.
+                        //
+                        // Another instance of the tool is working on the output container,
+                        //
                         result.Status = MigrationStatus.Skipped;
 
-                        _logger.LogWarning("Skipping asset {name} because it is not in a supported format!!!", asset.Data.Name);
+                        _logger.LogWarning("Another tool is working on the container {container} and output path: {output}",
+                                            Container,
+                                            Path);
                     }
                 }
+                else
+                {
+                    // The asset type is not supported in this milestone,
+                    // Mark the status as Skipped for caller to do the statistics.
+                    result.Status = MigrationStatus.Skipped;
+
+                    _logger.LogWarning("Skipping asset {name} because it is not in a supported format!!!", asset.Data.Name);
+                }                
 
                 await _tracker.UpdateMigrationStatus(container, result, cancellationToken);
 

--- a/azure/AzureStorageUploader.cs
+++ b/azure/AzureStorageUploader.cs
@@ -1,11 +1,13 @@
 ﻿using AMSMigrate.Ams;
 using AMSMigrate.Contracts;
+using AMSMigrate.Decryption;
 using Azure;
 using Azure.Core;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
 using Microsoft.Extensions.Logging;
+using System.Reflection.PortableExecutable;
 using System.Text;
 
 namespace AMSMigrate.Azure
@@ -70,17 +72,43 @@ namespace AMSMigrate.Azure
             await outputBlob.UploadAsync(content, options, cancellationToken: cancellationToken);
         }
 
+        /// <summary>
+        /// Take the source blob, update the content to a destination container.
+        /// </summary>
+        /// <param name="containerName">The destination container.</param>
+        /// <param name="fileName">The output blob in the destination container.</param>
+        /// <param name="blob">The source blob.</param>
+        /// <param name="aesTransform">The optional AesTransform for source content decryption.</param>
+        /// <param name="cancellationToken">The cancellaton token for the async operation.</param>
+        /// <returns></returns>
         public async Task UploadBlobAsync(
             string containerName,
             string fileName,
             BlockBlobClient blob,
+            AesCtrTransform? aesTransform,
             CancellationToken cancellationToken)
         {
             var container = _blobServiceClient.GetBlobContainerClient(containerName);
             await container.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
             var outputBlob = container.GetBlockBlobClient(fileName);
-            var operation = await outputBlob.StartCopyFromUriAsync(blob.Uri, cancellationToken: cancellationToken);
-            await operation.WaitForCompletionAsync(cancellationToken);
+
+            if (aesTransform == null)
+            {
+                var operation = await outputBlob.StartCopyFromUriAsync(blob.Uri, cancellationToken: cancellationToken);
+                await operation.WaitForCompletionAsync(cancellationToken);
+            }
+            else
+            {
+                // The input asset is encrypted, extract the clear content to the destination container
+                // so that the media content can be used after the asset migration without knowing the initial content key.
+                var blobStream = new MemoryStream();
+
+                await AssetDecryptor.DecryptTo(aesTransform, blob, blobStream, cancellationToken);
+
+                blobStream.Position = 0;
+
+                await outputBlob.UploadAsync(blobStream, cancellationToken: cancellationToken);
+            }
         }
 
         /// <summary>

--- a/decryption/AesCtrTransform.cs
+++ b/decryption/AesCtrTransform.cs
@@ -1,0 +1,228 @@
+//-----------------------------------------------------------------------
+// <copyright company="Microsoft">
+//     Copyright (C) Microsoft Corporation. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace AMSMigrate.Decryption
+{
+    /// <summary>
+    /// An implementation of the ICryptoTransform interface that implements the 
+    /// <see href="https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#CTR">AES Counter Mode</see>
+    /// encryption used for the Azure Media Services Storage Encryption.  
+    /// Note that the encryption and decryption transforms are the same for AES Counter Mode.
+    /// </summary>
+    public class AesCtrTransform : ICryptoTransform
+    {
+        private const int AesBlockSize = 16;
+        private readonly ulong _initializationVector;
+        private ICryptoTransform? _transform;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AesCtrTransform" /> class.  Note that the given initialization
+        /// vector and file offset are used to determine the starting counter value used in the AES Counter Mode algorithm.
+        /// </summary>
+        /// <param name="transform">an ICryptoTransform that implements the AES algorithm in Electronic Codebook mode (ECB)</param>
+        /// <param name="iv">initialization vector for the encryption</param>
+        /// <param name="fileOffset">file offset</param>
+        public AesCtrTransform(ICryptoTransform transform, ulong iv, long fileOffset)
+        {
+            if (fileOffset < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(fileOffset), "fileOffset cannot be less than zero");
+            }
+
+            _initializationVector = iv;
+            _transform = transform;
+            FileOffset = fileOffset;
+        }
+
+        private delegate void AsyncAesDelegate(byte[] data, int offset, int length, long fileOffset);
+
+        /// <summary>
+        /// Gets or sets the file offset used to determine the counter value used in the AES Counter Mode algorithm.
+        /// </summary>
+        public long FileOffset { get; set; }
+
+        #region ICryptoTransformMembers
+
+        /// <summary>
+        /// Gets the input block size.
+        /// </summary>
+        public int InputBlockSize
+        {
+            get { return 1; }
+        }
+
+        /// <summary>
+        /// Gets the output block size.
+        /// </summary>
+        public int OutputBlockSize
+        {
+            get { return 1; }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether multiple blocks can be transformed.
+        /// </summary>
+        public bool CanTransformMultipleBlocks
+        {
+            get { return true; }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the current transform can be reused.
+        /// </summary>
+        public bool CanReuseTransform
+        {
+            get { return false; }
+        }
+
+        /// <summary>
+        /// Transforms the specified region of the input byte array and copies the resulting transform to the specified region of the output byte array.
+        /// </summary>
+        /// <param name="inputBuffer">The input for which to compute the transform. </param>
+        /// <param name="inputOffset">The offset into the input byte array from which to begin using data. </param>
+        /// <param name="inputCount">The number of bytes in the input byte array to use as data. </param>
+        /// <param name="outputBuffer">The output to which to write the transform. </param>
+        /// <param name="outputOffset">The offset into the output byte array from which to begin writing data. </param>
+        /// <returns>The number of bytes written.</returns>
+        public int TransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset)
+        {
+            Array.Copy(inputBuffer, inputOffset, outputBuffer, outputOffset, inputCount);
+            AesCtr(outputBuffer, outputOffset, inputCount, FileOffset);
+            FileOffset += inputCount;
+
+            return inputCount;
+        }
+
+        /// <summary>
+        /// Transforms the specified region of the specified byte array.
+        /// </summary>
+        /// <param name="inputBuffer">The input for which to compute the transform. </param>
+        /// <param name="inputOffset">The offset into the byte array from which to begin using data. </param>
+        /// <param name="inputCount">The number of bytes in the byte array to use as data. </param>
+        /// <returns>The computed transform.</returns>
+        public byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount)
+        {
+            byte[] tempOutputBuffer = new byte[inputCount];
+
+            if (inputCount != 0)
+            {
+                TransformBlock(inputBuffer, inputOffset, inputCount, tempOutputBuffer, 0);
+            }
+
+            return tempOutputBuffer;
+        }
+
+        #endregion
+
+        #region IDisposeMembers
+
+        /// <summary>
+        /// Helps implement the IDisposable pattern.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+
+            // Take this object off the finalization queue and prevent the finalization
+            // code from running a second time.
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Helps implement the IDisposable pattern.
+        /// </summary>
+        /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (_transform != null)
+                {
+                    _transform.Dispose();
+                    _transform = null;
+                }
+            }
+        }
+
+        #endregion
+
+        private static void ConvertToBigEndianBytes(ulong original, byte[] outputBuffer, int indexToWriteTo)
+        {
+            byte[] originalAsBytes = BitConverter.GetBytes(original);
+
+            int destIndex = indexToWriteTo;
+            for (int sourceIndex = originalAsBytes.Length - 1; sourceIndex >= 0; sourceIndex--)
+            {
+                outputBuffer[destIndex] = originalAsBytes[sourceIndex];
+                destIndex++;
+            }
+        }
+
+        private void AesCtr(byte[] data, int offset, int length, long fileOffset)
+        {
+            if (offset < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(offset), offset, "Negative values are not allowed for offset.");
+            }
+
+            if (length < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(length), length, "Negative values are not allowed for length.");
+            }
+
+            if (fileOffset < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(fileOffset), fileOffset, "Negative values are not allowed for fileOffset.");
+            }
+
+            //
+            //  The fileOffset represents the number of bytes from the start of the file that
+            //  data[offset] was copied from.  We need to convert this byte offset into a block
+            //  offset (number of 16 byte blocks from the front of the file) and the byte offset 
+            //  within the block.
+            //
+            long offsetFromStartOfFileToFirstByteToProcess = fileOffset;
+            ulong currentBlock = Convert.ToUInt64(offsetFromStartOfFileToFirstByteToProcess) / AesBlockSize;
+            int startByteInFirstBlock = Convert.ToInt32(offsetFromStartOfFileToFirstByteToProcess % AesBlockSize);
+
+            //
+            //  Calculate the byte length of the cryptostream
+            //
+            int totalLength = startByteInFirstBlock + length;
+            int totalBlockCount = (totalLength / AesBlockSize) + ((totalLength % AesBlockSize > 0) ? 1 : 0);
+            int cryptoStreamLength = totalBlockCount * AesBlockSize;
+
+            //
+            //  Write the data to encrypt to the cryptostream
+            //
+            byte[] initializationVectorAsBigEndianBytes = new byte[8];
+            byte[] cryptoStream = new byte[cryptoStreamLength];
+            ConvertToBigEndianBytes(_initializationVector, initializationVectorAsBigEndianBytes, 0);
+
+            for (int i = 0; i < totalBlockCount; i++)
+            {
+                Array.Copy(initializationVectorAsBigEndianBytes, 0, cryptoStream, i * 16, initializationVectorAsBigEndianBytes.Length);
+                ConvertToBigEndianBytes(currentBlock, cryptoStream, (i * 16) + 8);
+                currentBlock++;
+            }
+
+            _transform?.TransformBlock(cryptoStream, 0, cryptoStream.Length, cryptoStream, 0);
+
+            int cryptoStreamIndex = startByteInFirstBlock;
+            int dataIndex = offset;
+            while (dataIndex < (offset + length))
+            {
+                data[dataIndex] ^= cryptoStream[cryptoStreamIndex];
+
+                // increment our indexes
+                cryptoStreamIndex++;
+                dataIndex++;
+            }
+        }
+    }
+}

--- a/decryption/AssetDecryptor.cs
+++ b/decryption/AssetDecryptor.cs
@@ -1,0 +1,121 @@
+﻿//-----------------------------------------------------------------------
+// <copyright company="Microsoft">
+//     Copyright (C) Microsoft Corporation. All rights reserved.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Security.Cryptography;
+using System.Threading;
+using Azure.ResourceManager.Media.Models;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Blobs.Specialized;
+
+namespace AMSMigrate.Decryption
+{
+    /// <summary>
+    /// Helper class to decrypt asset blobs when the asset was uploaded with storeage-encryption enabled.
+    /// </summary>
+    public static class AssetDecryptor
+    {
+        /// <summary>
+        /// Get an new instance of AesCtrTransform for a specific blob of an asset or a track of the LiveToVOD asset.
+        /// </summary>
+        /// <param name="storageDecryptInfo">The decryption information for the asset.</param>
+        /// <param name="assetFileName">The asset file name, it could be for a single blob or a media track.</param>
+        /// <param name="forTrack">true means it is for a media track.</param>
+        /// <returns>The instance of AesCtrTransform.</returns>
+        public static AesCtrTransform? GetAesCtrTransform(StorageEncryptedAssetDecryptionInfo? storageDecryptInfo, string assetFileName, bool forTrack = false)
+        {
+            AesCtrTransform? aesTransform = null;
+
+            if (storageDecryptInfo != null)
+            {
+                foreach (var meta in storageDecryptInfo.AssetFileEncryptionMetadata)
+                {
+                    bool hasIv = false;
+
+                    if (forTrack)
+                    {
+                        // The assetFileName is for a media track, it is the prefix of all fragblob's blob name.
+                        // All the Fragblobs for a specific track share the same IV.
+                        if (assetFileName.StartsWith(meta.AssetFileName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            hasIv = true;
+                        }
+                    }
+                    else
+                    {
+                        // This is a single asset file inside the root folder of asset container.
+                        // such as .mp4, .ism, .ismc etc.
+
+                        if (assetFileName.Equals(meta.AssetFileName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            hasIv = true;
+                        }
+                    }
+
+                    if (hasIv)
+                    {
+                        var initializationVector = Convert.ToUInt64(meta.InitializationVector);
+
+                        using (var aesProvider = Aes.Create())
+                        {
+                            aesProvider.Mode = CipherMode.ECB;
+                            aesProvider.Padding = PaddingMode.None;
+
+                            aesProvider.Key = storageDecryptInfo.Key;
+
+                            var transform = aesProvider.CreateEncryptor();
+
+                            aesTransform = new AesCtrTransform(transform, initializationVector, 0);
+                        }
+
+                        break;
+                    }
+                }
+            }
+
+            return aesTransform;
+        }
+
+        /// <summary>
+        /// Download the blob and decrypt it to an output stream.
+        /// </summary>
+        /// <param name="aesTransform">The AesCtrTransform for the decryption of the source blob. </param>
+        /// <param name="sourceBlob">The source blob.</param>
+        /// <param name="outputStream">The output stream that holds the decrypted content.</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <returns></returns>
+        public static async Task DecryptTo(AesCtrTransform aesTransform, BlockBlobClient sourceBlob, Stream outputStream, CancellationToken cancellationToken)
+        {
+            using BlobDownloadStreamingResult result = await sourceBlob.DownloadStreamingAsync(cancellationToken: cancellationToken);
+
+            using (CryptoStream cryptoStream = new CryptoStream(result.Content, aesTransform, CryptoStreamMode.Read))
+            {
+                cryptoStream.CopyTo(outputStream);
+            }
+        }
+
+        /// <summary>
+        /// Download the blob and decrypt it to an output file.
+        /// </summary>
+        /// <param name="aesTransform">The AesCtrTransform for the decryption of the source blob. </param>
+        /// <param name="sourceBlob">The source blob. </param>
+        /// <param name="outputFilePath">The output file path that holds the decrypted content.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns></returns>
+        public static async Task DecryptTo(AesCtrTransform aesTransform, BlockBlobClient sourceBlob, string outputFilePath, CancellationToken cancellationToken)
+        {
+            using BlobDownloadStreamingResult result = await sourceBlob.DownloadStreamingAsync(cancellationToken: cancellationToken);
+
+            using (FileStream fileStream = new FileStream(outputFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read))
+            {
+                using (CryptoStream cryptoStream = new CryptoStream(result.Content, aesTransform, CryptoStreamMode.Read))
+                {
+                    cryptoStream.CopyTo(fileStream);
+                    fileStream.Flush();
+                }
+            }
+        }
+    }
+}

--- a/pipes/BlobPipe.cs
+++ b/pipes/BlobPipe.cs
@@ -1,4 +1,7 @@
-﻿using Azure.Storage.Blobs;
+﻿
+using AMSMigrate.Decryption;
+using Azure.ResourceManager.Media.Models;
+using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
 using Microsoft.Extensions.Logging;
@@ -10,21 +13,35 @@ namespace AMSMigrate.Pipes
     {
         private readonly ILogger _logger;
         private readonly BlockBlobClient _blob;
-        public BlobStream(BlobContainerClient container, string blobName, ILogger logger) :
-            this(container.GetBlockBlobClient(blobName), logger)
+        private readonly StorageEncryptedAssetDecryptionInfo? _decryptInfo;
+
+        public BlobStream(BlobContainerClient container, string blobName, StorageEncryptedAssetDecryptionInfo? decryptInfo, ILogger logger) :
+            this(container.GetBlockBlobClient(blobName), decryptInfo, logger)
         {
         }
 
-        public BlobStream(BlockBlobClient blob, ILogger logger)
+        public BlobStream(BlockBlobClient blob, StorageEncryptedAssetDecryptionInfo? decryptInfo, ILogger logger)
         {
             _blob = blob;
             _logger = logger;
+            _decryptInfo = decryptInfo;
         }
 
         public async Task DownloadAsync(Stream stream, CancellationToken cancellationToken)
         {
             _logger.LogDebug("Begin downloading {name}", _blob.Name);
-            await _blob.DownloadToAsync(stream, cancellationToken: cancellationToken);
+
+            using var aesTransform = AssetDecryptor.GetAesCtrTransform(_decryptInfo, _blob.Name, false);
+
+            if (aesTransform != null)
+            {
+                await AssetDecryptor.DecryptTo(aesTransform, _blob, stream, cancellationToken);
+            }
+            else
+            {
+                await _blob.DownloadToAsync(stream, cancellationToken: cancellationToken);
+            }
+
             _logger.LogDebug("Finished download of {name}", _blob.Name);
         }
 
@@ -44,10 +61,10 @@ namespace AMSMigrate.Pipes
     {
         private readonly BlobStream _blobStream;
 
-        public BlobPipe(string filePath, BlobContainerClient container, ILogger logger, PipeDirection direction = PipeDirection.Out)
+        public BlobPipe(string filePath, BlobContainerClient container, StorageEncryptedAssetDecryptionInfo? decryptInfo, ILogger logger, PipeDirection direction = PipeDirection.Out)
             : base(filePath, direction)
         {
-            _blobStream = new BlobStream(container, Path.GetFileName(filePath), logger);
+            _blobStream = new BlobStream(container, Path.GetFileName(filePath), decryptInfo, logger);
         }
 
         public async Task DownloadAsync(CancellationToken cancellationToken)

--- a/transform/AssetTransform.cs
+++ b/transform/AssetTransform.cs
@@ -1,16 +1,18 @@
 ﻿using AMSMigrate.Ams;
 using AMSMigrate.Contracts;
+using AMSMigrate.Decryption;
 using Azure.ResourceManager.Media;
+using Azure.ResourceManager.Media.Models;
 using Azure.Storage.Blobs;
 using Microsoft.Extensions.Logging;
 
 namespace AMSMigrate.Transform
 {
-    public record AssetRecord(MediaServicesAccountResource Account, MediaAssetResource Asset, string AssetName, BlobContainerClient Container, Manifest? Manifest, ClientManifest? ClientManifest, string? OutputManifest) 
-        : AssetDetails(AssetName, Container, Manifest, ClientManifest, OutputManifest)
+    public record AssetRecord(MediaServicesAccountResource Account, MediaAssetResource Asset, string AssetName, BlobContainerClient Container, Manifest? Manifest, ClientManifest? ClientManifest, string? OutputManifest, StorageEncryptedAssetDecryptionInfo? DecryptInfo) 
+        : AssetDetails(AssetName, Container, Manifest, ClientManifest, OutputManifest, DecryptInfo)
     {
         public AssetRecord(MediaServicesAccountResource account, MediaAssetResource asset, AssetDetails details):
-            this(account, asset, details.AssetName, details.Container, details.Manifest, details.ClientManifest, details.OutputManifest)
+            this(account, asset, details.AssetName, details.Container, details.Manifest, details.ClientManifest, details.OutputManifest, details.DecryptInfo)
         {
         }
     }

--- a/transform/BasePackager.cs
+++ b/transform/BasePackager.cs
@@ -160,12 +160,12 @@ namespace AMSMigrate.Transform
                 if (tracks.Count == 1 && tracks[0].IsMultiFile)
                 {
                     var track = tracks[0];
-                    var multiFileStream = new MultiFileStream(_assetDetails.Container, track, _assetDetails.ClientManifest!, _logger);
+                    var multiFileStream = new MultiFileStream(_assetDetails.Container, track, _assetDetails.ClientManifest!, _assetDetails.DecryptInfo, _logger);
                     return new MultiFilePipe(file, multiFileStream);
                 }
                 else
                 {
-                    return new BlobPipe(Path.Combine(workingDirectory, file), _assetDetails.Container, _logger) as Pipe;
+                    return new BlobPipe(Path.Combine(workingDirectory, file), _assetDetails.Container, _assetDetails.DecryptInfo, _logger) as Pipe;
                 }
             }).ToArray();
         }
@@ -209,13 +209,13 @@ namespace AMSMigrate.Transform
             if (tracks.Count == 1 && tracks[0].IsMultiFile)
             {
                 var track = tracks[0];
-                var multiFileStream = new MultiFileStream(_assetDetails.Container, track, _assetDetails.ClientManifest!, _logger);
+                var multiFileStream = new MultiFileStream(_assetDetails.Container, track, _assetDetails.ClientManifest!, _assetDetails.DecryptInfo, _logger);
                 source = new MultiFilePipe(filePath, multiFileStream);
             }
             else
             {
                 var blob = _assetDetails.Container.GetBlockBlobClient(Path.GetFileName(filePath));
-                source = new BlobSource(blob, _logger);
+                source = new BlobSource(blob, _assetDetails.DecryptInfo, _logger);
             }
 
             if (TransmuxedDownload)

--- a/transform/StorageExtensions.cs
+++ b/transform/StorageExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using AMSMigrate.Ams;
 using AMSMigrate.Contracts;
+using AMSMigrate.Decryption;
 using Azure.ResourceManager.Media;
+using Azure.ResourceManager.Media.Models;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
@@ -26,6 +28,7 @@ namespace AMSMigrate.Transform
             this BlobContainerClient container,
             string name,
             ILogger logger,
+            StorageEncryptedAssetDecryptionInfo? decryptInfo,
             CancellationToken cancellationToken)
         {
             BlobItem[]? manifests = null;
@@ -55,37 +58,72 @@ namespace AMSMigrate.Transform
                     container.Name,
                     manifests[0].Name);
                 }
-                manifest = await GetManifestAsync(container, manifests[0].Name, logger, cancellationToken);
+                manifest = await GetManifestAsync(container, manifests[0].Name, logger, decryptInfo, cancellationToken);
                 logger.LogTrace("Found manifest {name} of format {format} in container {container}", manifest.FileName, manifest.Format, container.Name);
             }
 
             return manifest;
         }
 
-        public static async Task<ClientManifest> GetClientManifestAsync(this BlobContainerClient container, Manifest manifest, ILogger logger, CancellationToken cancellationToken)
+        public static async Task<ClientManifest> GetClientManifestAsync(this BlobContainerClient container, Manifest manifest, ILogger logger, StorageEncryptedAssetDecryptionInfo? decryptInfo, CancellationToken cancellationToken)
         {
             if (manifest.ClientManifest == null) throw new ArgumentException("No client manifest found", nameof(manifest));
             var blob = container.GetBlockBlobClient(manifest.ClientManifest);
             logger.LogDebug("Getting client manifest {manifest} for asset", manifest.ClientManifest);
-            using BlobDownloadStreamingResult result =
-                await blob.DownloadStreamingAsync(cancellationToken: cancellationToken);
 
-            return ClientManifest.Parse(result.Content, blob.Name, logger);
+            Stream ismcStream;
+
+            using AesCtrTransform? aesTransform = AssetDecryptor.GetAesCtrTransform(decryptInfo, manifest.ClientManifest, false);
+
+            if (aesTransform != null)
+            {
+                ismcStream = new MemoryStream();
+
+                await AssetDecryptor.DecryptTo(aesTransform, blob, ismcStream, cancellationToken);
+
+                ismcStream.Position = 0;
+            }
+            else
+            {
+                using BlobDownloadStreamingResult result =
+                        await blob.DownloadStreamingAsync(cancellationToken: cancellationToken);
+
+                ismcStream = result.Content;
+            }            
+
+            return ClientManifest.Parse(ismcStream, blob.Name, logger);
         }
 
         public static async Task<Manifest> GetManifestAsync(
             this BlobContainerClient container,
             string manifestName,
             ILogger logger,
+            StorageEncryptedAssetDecryptionInfo? decryptionInfo,
             CancellationToken cancellationToken)
         {
             var blobClient = container.GetBlockBlobClient(manifestName);
 
-            using BlobDownloadStreamingResult result =
-                await blobClient.DownloadStreamingAsync(cancellationToken: cancellationToken);
+            Stream ismStream;
 
-            var manifest = Manifest.Parse(result.Content, manifestName, logger);
-            return manifest;
+            using AesCtrTransform? aesTransform = AssetDecryptor.GetAesCtrTransform(decryptionInfo, manifestName, false);
+
+            if (aesTransform != null)
+            {
+                ismStream = new MemoryStream();
+
+                await AssetDecryptor.DecryptTo(aesTransform, blobClient, ismStream, cancellationToken);
+
+                ismStream.Position = 0;
+            }
+            else
+            {
+                using BlobDownloadStreamingResult result =
+                    await blobClient.DownloadStreamingAsync(cancellationToken: cancellationToken);
+
+                ismStream = result.Content;
+            }            
+
+            return Manifest.Parse(ismStream, manifestName, logger); ;
         }
 
         public static async Task<IEnumerable<BlockBlobClient>> GetListOfBlobsAsync(
@@ -142,7 +180,15 @@ namespace AMSMigrate.Transform
             bool includeClientManifest = true)
         {
             var container = await asset.GetContainerAsync(cancellationToken);
-            return await container.GetDetailsAsync(logger, cancellationToken, outputManifestname, asset.Data.Name, includeClientManifest);
+            StorageEncryptedAssetDecryptionInfo? decryptInfo = null;
+
+            if (asset.Data.StorageEncryptionFormat != MediaAssetStorageEncryptionFormat.None)
+            {
+                // The asset is encypted with its own key and list of IVs.
+                decryptInfo = await asset.GetEncryptionKeyAsync(cancellationToken);
+            }
+
+            return await container.GetDetailsAsync(logger, cancellationToken, outputManifestname, asset.Data.Name, includeClientManifest, decryptInfo);
         }
 
         public static async Task<AssetDetails> GetDetailsAsync(
@@ -151,16 +197,17 @@ namespace AMSMigrate.Transform
             CancellationToken cancellationToken,
             string? outputManifestname,
             string? name = null,
-            bool includeClientManifest = true)
+            bool includeClientManifest = true,
+            StorageEncryptedAssetDecryptionInfo? decryptInfo = null)
         {
             name = name ?? container.Name;
-            var manifest = await container.LookupManifestAsync(name, logger, cancellationToken);
+            var manifest = await container.LookupManifestAsync(name, logger, decryptInfo, cancellationToken);
             ClientManifest? clientManifest = null;
             if (manifest != null && includeClientManifest && manifest.IsLiveArchive)
             {
-                clientManifest = await container.GetClientManifestAsync(manifest, logger, cancellationToken);
+                clientManifest = await container.GetClientManifestAsync(manifest, logger, decryptInfo, cancellationToken);
             }
-            return new AssetDetails(name, container, manifest, clientManifest, outputManifestname);
+            return new AssetDetails(name, container, manifest, clientManifest, outputManifestname, decryptInfo);
         }
     }
 }


### PR DESCRIPTION
Description:

   Some legacy AMS assets might be encrypted in storage side with customer's Key, it could be generated by RestV2 APIs
   or the RestV2 LiveChannels.

   This change adds logic to extract the decryption info for a specific Asset, figure out the key and InitializationVector for
   asset file, (the Vitual Assest File for LiveToVOD assets for each media track).

   AesCtrTransform is the central class does the actual decryption work with a content key and IV for a specific input stream.

   AssetDecryptor is a helper class to return ICryptoTransform for a specific blob/virtual media track, decryt the blob into a output stream or output file.

   AssetRecord contains an extra property for StorageEncryptedAssetDecryptionInfo.

   Update the related classes to apply the decryption work when an asset is encrypted to get the clear content for a specific blob.

   so that the remaining pipeline keeps working for both Storage-Encrypted assets and clear assets.

   Verified with the AMSE-generated asset with storage encryption.