### PR TITLE
Copy over the ContentType of source blob for storage-encrypted blobs …

### DIFF
--- a/azure/AzureStorageUploader.cs
+++ b/azure/AzureStorageUploader.cs
@@ -107,7 +107,14 @@ namespace AMSMigrate.Azure
 
                 blobStream.Position = 0;
 
-                await outputBlob.UploadAsync(blobStream, cancellationToken: cancellationToken);
+                var inputBlobHeaders = await blob.GetPropertiesAsync(cancellationToken: cancellationToken);
+
+                var httpHeader = new BlobHttpHeaders
+                {
+                    ContentType = inputBlobHeaders?.Value.ContentType ?? "application/octet-stream"
+                };
+
+                await outputBlob.UploadAsync(blobStream, httpHeader, cancellationToken: cancellationToken);
             }
         }
 


### PR DESCRIPTION
…that are not handled by the packager

Description

  Some blobs in input assets are directly copied over to destination folder,  such as .json file, thumbnail file etc.

  When they are not encrypted with customer's key, the code can transfer the headers from source blob to destination,
  When they are encrypted with customer's key, this new change ensures the ContentType header is transfered to the destionation folder,
  so that ContentType property is always available for all blobs in the destination folder.