### PR TITLE
Add support for smooth streaming asset migration.

### DIFF
--- a/ams/AssetMigrationTracker.cs
+++ b/ams/AssetMigrationTracker.cs
@@ -48,7 +48,10 @@ namespace AMSMigrate.Ams
         /// </summary>
         public bool IsSupportedAsset(bool enableLiveAsset)
         {
-            return (AssetType != null && (AssetType == AssetType_NonIsm || AssetType.StartsWith("mp4") || (enableLiveAsset && AssetType == "vod-fmp4")));
+            return (AssetType != null && (AssetType == AssetType_NonIsm 
+                || AssetType == "fmp4" 
+                || AssetType.StartsWith("mp4") 
+                || (enableLiveAsset && AssetType == "vod-fmp4")));
         }
 
         public AssetMigrationResult(MigrationStatus status = MigrationStatus.NotMigrated, Uri? outputPath = null, string? assetType = null, string? manifestName = null) : base(status)

--- a/contracts/Manifest.cs
+++ b/contracts/Manifest.cs
@@ -50,6 +50,8 @@ namespace AMSMigrate.Contracts
 
         // Check if the track is stored as one file per fragment.
         public bool IsMultiFile => string.IsNullOrEmpty(Path.GetExtension(Source));
+
+        public uint TrackID => uint.Parse(Parameters.Single(p => p.Name == "trackID").Value);
     }
 
     public class VideoTrack : Track

--- a/fmp4/Box.cs
+++ b/fmp4/Box.cs
@@ -752,7 +752,7 @@ namespace AMSMigrate.Fmp4
         /// </summary>
         /// <typeparam name="TChildBoxType">The type of the requested child box.</typeparam>
         /// <returns>A box of the requested type.</returns>
-        public TChildBoxType? GetExactlyOneChildBox<TChildBoxType>() where TChildBoxType : Box
+        public TChildBoxType GetExactlyOneChildBox<TChildBoxType>() where TChildBoxType : Box
         {
             IEnumerable<Box> boxes = _children.Where(b => b is TChildBoxType);
             int numBoxes = boxes.Count();
@@ -776,7 +776,7 @@ namespace AMSMigrate.Fmp4
                         GetType().Name, childBoxName, numBoxes));
             }
 
-            return boxes.Single() as TChildBoxType;
+            return (TChildBoxType) boxes.Single();
         }
 
         /// <summary>

--- a/fmp4/FullBox.cs
+++ b/fmp4/FullBox.cs
@@ -126,7 +126,7 @@ namespace AMSMigrate.Fmp4
             {
                 return _version;
             }
-            protected set
+            set
             {
                 _version = value;
                 SetDirty();

--- a/fmp4/MP4BoxType.cs
+++ b/fmp4/MP4BoxType.cs
@@ -31,6 +31,7 @@ namespace AMSMigrate.Fmp4
         public const UInt32 mdia = 0x6D646961; // 'mdia'
         public const UInt32 hdlr = 0x68646C72; // 'hdlr'
         public const UInt32 mdhd = 0x6D646864; // 'mdhd'
+        public const UInt32 mfra = 0x6D666661; // 'mfra'
 
 
         //===================================================================

--- a/transform/PackageTransform.cs
+++ b/transform/PackageTransform.cs
@@ -35,7 +35,9 @@ namespace AMSMigrate.Transform
             {
                 return false;
             }
-            return details.Manifest.Format.StartsWith("mp4") || (_globalOptions.EnableLiveAsset && details.Manifest.Format == "vod-fmp4");
+            return details.Manifest.Format.StartsWith("mp4") 
+                || details.Manifest.Format.Equals("fmp4") 
+                || (_globalOptions.EnableLiveAsset && details.Manifest.Format == "vod-fmp4");
         }
 
         protected override async Task<string> TransformAsync(

--- a/transform/ShakaPackager.cs
+++ b/transform/ShakaPackager.cs
@@ -60,10 +60,15 @@ namespace AMSMigrate.Transform
             List<string> arguments = new(SelectedTracks.Select((t, i) =>
             {
                 var ext = t.IsMultiFile ? MEDIA_FILE : string.Empty;
-                var index = Inputs.Count == 1 ? 0 : Inputs.IndexOf($"{t.Source}{ext}");
-                var stream = Inputs.Count == 1? i.ToString(): t.Type.ToString().ToLowerInvariant();
+                var file = $"{t.Source}{ext}";
+                var index = Inputs.IndexOf(file);
+                var multiTrack = TransmuxedDownload && FileToTrackMap[file].Count > 1;
+                var inputFile = multiTrack ? 
+                    Path.Combine(Path.GetDirectoryName(inputs[index])!, $"{Path.GetFileNameWithoutExtension(file)}_{t.TrackID}{Path.GetExtension(file)}") :
+                    inputs[index];
+                var stream = t.Type.ToString().ToLowerInvariant();
                 var language = string.IsNullOrEmpty(t.SystemLanguage) || t.SystemLanguage == "und" ? string.Empty : $"language={t.SystemLanguage},";
-                return $"stream={stream},in={inputs[index]},out={outputs[i]},{language}playlist_name={manifests[i]}{drm_label}";
+                return $"stream={stream},in={inputFile},out={outputs[i]},{language}playlist_name={manifests[i]}{drm_label}";
             }));
             var dash = manifests[manifests.Count - 1];
             var hls = manifests[manifests.Count - 2];


### PR DESCRIPTION
Use the MP4 parser to transmux smooth to a format that shaka can accept.
Always set 'trun' box version to 1 to support signed CTS.
Filter by track id since shaka fails  when file has multiple tracks but each moof has single track.
Fixes #87 and #88