### PR TITLE
Ability to specify the subscription of media account.

### DIFF
--- a/deployment/parameters.bicepparam
+++ b/deployment/parameters.bicepparam
@@ -3,20 +3,25 @@ using './deployment.bicep'
 // The media services account being migrated.
 param mediaAccountName = 'provenanceuswc'
 param mediaAccountRG = 'provenance'
+// If media account is in a different subscrtipion than where the migration is running.
+// param mediaAccountSubscription = ''
 
 // The storage account where migrated data is written.
 param storageAccountName = 'amsencodermsitest'
 param storageAccountRG = 'amsmediacore'
+// If the storage account is in a different subscription than where the migration is running.
+// param storageAccountSubscription = ''
 
 // setting to turn encryption on or off.
-
 param encrypt = false
+
 // The key vault to store encryption keys if encryption is turned on.
 param keyvaultname = 'mpprovenance'
 param keyvaultRG = 'provenance'
+// param keyvaultSubscription = ''
 
 //additional arguments.
 param arguments = [
   '-t'
-  '$web/deployment/\${AssetName}'
+  '\${AssetName}'
 ]

--- a/deployment/storageaccounts.bicep
+++ b/deployment/storageaccounts.bicep
@@ -9,7 +9,7 @@ param storageAccounts array
 
 module storageRoleAssignments './roleassignment.bicep' = [for storage in storageAccounts: {
   name: 'storageRoleAssignment-${split(storage, '/')[8]}'
-  scope: resourceGroup(split(storage, '/')[4])
+  scope: resourceGroup(split(storage, '/')[2], split(storage, '/')[4])
   params: {
     resourceName: split(storage, '/')[8]
     roleName: storageRoleName


### PR DESCRIPTION
The media and storage accounts can be in a different subscription than where the migration tool is running.
Use Contributor role for media account to support encrypted content.