### PR TITLE
For live archive, current strategy for unaligned audio and video

### DIFF
--- a/transform/TransMuxer.cs
+++ b/transform/TransMuxer.cs
@@ -2,7 +2,10 @@
 using AMSMigrate.Fmp4;
 using Azure.ResourceManager.Media.Models;
 using FFMpegCore;
+using FFMpegCore.Arguments;
+using FFMpegCore.Enums;
 using FFMpegCore.Pipes;
+using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Logging;
 using System.Text;
 
@@ -75,33 +78,86 @@ namespace AMSMigrate.Transform
                 }
             }
         }
-
-        public async Task TranscodeAudioAsync(string source, string destination, CancellationToken cancellationToken)
+        public class AudioDelayFilterArgument : IAudioFilterArgument
         {
-            var processor = FFMpegArguments
+            private readonly long _delay = 0;
+
+            public AudioDelayFilterArgument(long delay)
+            {
+                _delay = delay;
+            }
+            public string Key { get; } = "adelay";
+            public string Value => $"{_delay}:all=1";
+        }
+
+        public class AudioResample : IAudioFilterArgument
+        {
+            public string Key { get; } = "aresample";
+            public string Value => $"async=1";
+        }
+
+        public async Task TranscodeAudioAsync(string source, string destination, TranscodeAudioInfo transcodeAudioInfo, CancellationToken cancellationToken)
+        {
+            if (transcodeAudioInfo.AudioStartTime > transcodeAudioInfo.VideoStartTimeInAudioTimeScale)
+            {
+                long delayInMs = (transcodeAudioInfo.AudioStartTime - transcodeAudioInfo.VideoStartTimeInAudioTimeScale) * 1000 / transcodeAudioInfo.AudioTimeScale;
+                var processor = FFMpegArguments
                 .FromFileInput(source)
                 //.WithGlobalOptions(options => options.WithVerbosityLevel(FFMpegCore.Arguments.VerbosityLevel.Verbose))
-                .OutputToFile(destination, overwrite: false, options =>
+                .OutputToFile(destination, overwrite: true, options =>
+                options
+                .WithAudioFilters(
+                    audioFilterOptions =>
+                    {
+                        audioFilterOptions.Arguments.Add(new AudioDelayFilterArgument(delayInMs));
+                        if (transcodeAudioInfo.AudioStreamHasDiscontinuities)
+                        {
+                            audioFilterOptions.Arguments.Add(new AudioResample());
+                        }
+                    }
+                )
+                .WithAudioCodec(AudioCodec.Aac)
+                .ForceFormat("mp4")
+                .WithCustomArgument("-movflags cmaf"));
+
+                await RunAsync(processor, cancellationToken);
+
+            }
+            else if (transcodeAudioInfo.AudioStartTime <= transcodeAudioInfo.VideoStartTimeInAudioTimeScale)
+            {
+                if (transcodeAudioInfo.AudioStreamHasDiscontinuities)
                 {
-                    // TODO: add silence insertion, trim, resample + transcode
-                    // current just do cmaf copy
-                    bool addSilence = false;
-                    if (addSilence)
-                    {
-                        options
-                        .CopyChannel()
-                        .ForceFormat("mp4")
-                        .WithCustomArgument("-movflags cmaf");
-                    }
-                    else
-                    {
-                        options
-                        .CopyChannel()
-                        .ForceFormat("mp4")
-                        .WithCustomArgument("-movflags cmaf");
-                    }
-                });
-            await RunAsync(processor, cancellationToken);
+                    long trimInMs = (transcodeAudioInfo.VideoStartTimeInAudioTimeScale - transcodeAudioInfo.AudioStartTime) * 1000 / transcodeAudioInfo.AudioTimeScale;
+                    var processor = FFMpegArguments
+                    .FromFileInput(source, false, opt => opt.Seek(TimeSpan.FromMilliseconds(trimInMs)))
+                    //.WithGlobalOptions(options => options.WithVerbosityLevel(FFMpegCore.Arguments.VerbosityLevel.Verbose))
+                    .OutputToFile(destination, overwrite: true, options =>
+                    options
+                    .WithAudioFilters(
+                        audioFilterOptions =>
+                        {
+                            audioFilterOptions.Arguments.Add(new AudioResample());
+                        }
+                    )
+                    .WithAudioCodec(AudioCodec.Aac)
+                    .ForceFormat("mp4")
+                    .WithCustomArgument("-movflags cmaf"));
+                    await RunAsync(processor, cancellationToken);
+                }
+                else
+                {
+                    double trim = (transcodeAudioInfo.VideoStartTimeInAudioTimeScale - transcodeAudioInfo.AudioStartTime) * 1000.0 / transcodeAudioInfo.AudioTimeScale;
+                    var processor = FFMpegArguments
+                    .FromFileInput(source, false, opt => opt.Seek(TimeSpan.FromMilliseconds(trim)))
+                    //.WithGlobalOptions(options => options.WithVerbosityLevel(FFMpegCore.Arguments.VerbosityLevel.Verbose))
+                    .OutputToFile(destination, overwrite: false, options =>
+                    options
+                    .CopyChannel()
+                    .ForceFormat("mp4")
+                    .WithCustomArgument("-movflags cmaf"));
+                    await RunAsync(processor, cancellationToken);
+                }
+            } 
             // TODO: rewrite tfdt box from 0 based to video start time in audio time scale.
         }
     }


### PR DESCRIPTION
contents is to leave the video stream untouched, and change the audio stream by either insert silence at the beginning or trim the beginning of the audio stream.  if there are discontinuities in the audio stream, we will reencode with resample to fill in the gap with silence.

this commit adds the detection logic, and silence insertion.  The trim / reencode path is checked in but not tested yet.

also, we need to change the tdft flag on the audio stream since ffmpeg zero based it.