### PR TITLE
for live archive, change audio and video cmaf files to 0 based (i.e. …

### DIFF
--- a/pipes/MultiFileStream.cs
+++ b/pipes/MultiFileStream.cs
@@ -19,6 +19,8 @@ namespace AMSMigrate.Pipes
         private readonly string _trackPrefix;
         private readonly bool _isCloseCaption;
         private readonly StorageEncryptedAssetDecryptionInfo? _decryptInfo;
+        private ulong _startingTfdt = 0; //
+        private bool _firstTfdt = true;
 
         public MultiFileStream(
             BlobContainerClient container,
@@ -123,7 +125,12 @@ namespace AMSMigrate.Pipes
 
                 var fragment = new Fmp4Fragment(moofBox, mdatBox);
 
-                fragment.ReplaceTfxdWithTfdt();
+                ulong tfdt = fragment.ReplaceTfxdWithTfdt(_firstTfdt, _startingTfdt);
+                if (_firstTfdt)
+                {
+                    _firstTfdt = false;
+                    _startingTfdt = tfdt;
+                }
 
                 fragment.WriteTo(mp4Writer);
             }


### PR DESCRIPTION
…subtract by initial timestamp) to support dash.js (w/ vtt).  the timestamp in the vtt file is now not sync'ed, to be addressed later