### PR TITLE
Add a unique role to captions.

### DIFF
--- a/transform/BasePackager.cs
+++ b/transform/BasePackager.cs
@@ -61,7 +61,8 @@ namespace AMSMigrate.Transform
 
         public static bool IsLiveTextTrackSupported(Track track, ClientManifest clientManifest)
         {
-            return track.IsMultiFile && 
+            return track.Source.EndsWith(VTT_FILE) ||
+                track.IsMultiFile && 
                 // Choose the text track with a list of fragblobs for close captions.
                 clientManifest!.Streams.Any(
                     stream => (stream.Type == StreamType.Text &&


### PR DESCRIPTION
Allow multiple VTT captions for live archives.
In the rare case there are more than 3 captions for the same language we repeat the roles for now.