### PR TITLE
Cleanup code and make it more performant

### DIFF
--- a/ams/AzureResourceProvider.cs
+++ b/ams/AzureResourceProvider.cs
@@ -40,28 +40,16 @@ namespace AMSMigrate.Ams
             if (mediaServiceResource.GetRawResponse().Status == 200)
             {
                 storageAccounts = mediaServiceResource.Value.Data.StorageAccounts;
-                if (storageAccounts != null && storageAccounts.Any())
-                {
-                    foreach (var storageAccount in storageAccounts)
-                    {
-                        string? storageAccountId = storageAccount.Id;  
-                        ///subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.storage/storageaccounts/{accountName}
-                        if (!string.IsNullOrEmpty(storageAccountId))
-                        {
-                            string[] parts;
-                            parts = storageAccountId.Split('/');
-                            string resourceGroupName = parts[4];
-                            string storageAccName = parts[8];
-                            string subscriptionId = parts[2];
-                            var resourceGroupId = ResourceGroupResource.CreateResourceIdentifier(
-                                 subscriptionId,
-                                 resourceGroupName);
-                            var resourceGroup = _armClient.GetResourceGroupResource(resourceGroupId);
-                            _storageResourceGroups.Add(storageAccName, resourceGroup);
-                       }
-                    }
-                }
 
+                foreach (var storageAccount in storageAccounts)
+                {
+                    var storageAccountId = storageAccount.Id;  
+                    var resourceGroupId = ResourceGroupResource.CreateResourceIdentifier(
+                            storageAccountId.SubscriptionId!,
+                            storageAccountId.ResourceGroupName!);
+                    var resourceGroup = _armClient.GetResourceGroupResource(resourceGroupId);
+                    _storageResourceGroups.Add(storageAccountId.Name, resourceGroup);
+                }
             }
         }
 

--- a/transform/ShakaPackager.cs
+++ b/transform/ShakaPackager.cs
@@ -62,11 +62,7 @@ namespace AMSMigrate.Transform
                             videoStream = stream;
                             numVideoStreams++;
                         }
-                    }
-
-                    foreach (var stream in clientManifest.Streams)
-                    {
-                        if (stream.Type == StreamType.Audio)
+                        else if (stream.Type == StreamType.Audio)
                         {
                             audioStream = stream;
                             numAudioStreams++;


### PR DESCRIPTION
Description:

   This is to follow up previous checkins and make the code better performant:

   1) When checking the StreamIndex in client manifest, no need to do two round of checks for video/audio streams.
   2) When getting the Storage account's subscriptionId, resourceGroupName and acctName, no need to do string parsing again.