### PR TITLE
Take use the default segment duration with ShakaPackager instead of h…

### DIFF
--- a/transform/ShakaPackager.cs
+++ b/transform/ShakaPackager.cs
@@ -167,8 +167,6 @@ namespace AMSMigrate.Transform
 
             arguments.Add("--temp_dir");
             arguments.Add(_options.WorkingDirectory);
-            arguments.Add("--segment_duration");
-            arguments.Add("2");
             arguments.Add("--mpd_output");
             arguments.Add(dash);
             arguments.Add("--hls_master_playlist_output");


### PR DESCRIPTION
…ard-coded 2s

Description:

   Remove option --segment_duration 2 from the command line of ShakaPackager, so that the default
   segment duration is used when ShakaPackager generates the final cmaf mp4 files for audio/video tracks.

   The default 6s is also recommended by the HLS spec for VOD content, the HLS playlist file also has smaller size than  working with 2s duration,
   It has less chance to generate a final segment duration with much bigger duration than average one,
   especially when input asset contains GOP of 3.9x second while most of them are 2s.