### PR TITLE
Report the full HLS URL and DASH URL in HTML report for Analyze command

### DIFF
--- a/ams/ReportGenerator.cs
+++ b/ams/ReportGenerator.cs
@@ -46,11 +46,11 @@ namespace AMSMigrate.Ams
     <table>
       <thead>
       <tr>
-        <th style=""width:20%"">Asset Name</t>
-        <th style=""width:6%"">AssetType</th>
+        <th style=""width:15%"">Asset Name</t>
+        <th style=""width:5%"">AssetType</th>
         <th style=""width:8%"">MigrateStatus</th>
-        <th style=""width:56%"">OutputPath</th>
-        <th style=""width:10%"">ManifestName</th>
+        <th style=""width:36%"">OutputHlsUrl</th>
+        <th style=""width:36%"">OutputDashUrl</th>
       </tr>
       </thead>
       <tbody>");
@@ -70,10 +70,15 @@ namespace AMSMigrate.Ams
             lock (this)
             {
                 _writer.Write($"<tr><td>{result.AssetName}</td><td>{result.AssetType}</td><td>{result.Status}</td><td>");
-                if (result.OutputPath != null)
-                    _writer.Write($"<a href=\"{result.OutputPath}\">{result.OutputPath}</a>");
+                if (result.OutputHlsUrl != null)
+                    _writer.Write($"<a href=\"{result.OutputHlsUrl}\">{result.OutputHlsUrl}</a>");
 
-                _writer.Write($"</td><td>{result.ManifestName}</td>");
+                _writer.Write($"</td><td>");
+
+                if (result.OutputDashUrl != null)
+                    _writer.Write($"<a href=\"{result.OutputDashUrl}\">{result.OutputDashUrl}</a>");
+
+                _writer.Write($"</td>");
 
                 _writer.WriteLine($"</tr>");
             }

--- a/transform/AnalyzeTransform.cs
+++ b/transform/AnalyzeTransform.cs
@@ -15,5 +15,9 @@ namespace AMSMigrate.Transform
         public int Locators { get; internal set; }
 
         public string AssetName { get; set; }
+
+        public Uri? OutputHlsUrl => OutputPath != null ? new Uri(OutputPath!, (ManifestName + ".m3u8")) : null;
+
+        public Uri? OutputDashUrl => OutputPath != null ? new Uri(OutputPath!, (ManifestName + ".mpd")) : null;
     }
 }


### PR DESCRIPTION
Description:

  The current report page contains OutputPath and ManifestName, customer needs to combine them to generate HLS/DASH URLs.

  The new HTML page just directly report OutputHlsUrl and OutputDashUrl, it is easier for customer to take the URL to the player.