### PR TITLE
Refactor logging to fix hang issues.

### DIFF
--- a/AMSMigrate.csproj
+++ b/AMSMigrate.csproj
@@ -25,23 +25,25 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.10.0" />
+    <PackageReference Include="Azure.Identity" Version="1.10.1" />
     <PackageReference Include="Azure.Monitor.Query" Version="1.2.0" />
     <PackageReference Include="Azure.ResourceManager.Media" Version="1.2.0" />
     <PackageReference Include="Azure.ResourceManager.Storage" Version="1.1.1" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.5.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.17.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.18.0" />
     <PackageReference Include="FFMpegCore" Version="5.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.TraceSource" Version="7.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
+    <PackageReference Include="Serilog.Expressions" Version="3.4.1" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Spectre.Console" Version="0.47.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.Linq.Async.Queryable" Version="6.0.1" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="System.Threading.Channels" Version="7.0.0" />
-    <PackageReference Include="vertical-spectreconsolelogger" Version="0.10.1-dev.20230712.19" />
+    <PackageReference Include="vertical-spectreconsolelogger" Version="0.10.1-dev.20230901.27" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Program.cs
+++ b/Program.cs
@@ -8,18 +8,18 @@ using Azure.Identity;
 using Azure.Storage.Blobs;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Console;
+using Serilog;
+using Serilog.Events;
 using Spectre.Console;
 using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Help;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
-using System.Diagnostics;
 using System.Text;
 using Vertical.SpectreLogger;
 using Vertical.SpectreLogger.Core;
-using Vertical.SpectreLogger.Options;
-using Events = AMSMigrate.Contracts.Events;
 
 namespace AMSMigrate
 {
@@ -145,9 +145,8 @@ This command will forcibly revert migrated assets that have failed back to their
         static async Task SetupDependencies(InvocationContext context, Func<InvocationContext, Task> next)
         {
             var globalOptions = GlobalOptionsBinder.GetValue(context.BindingContext);
-            using var listener = new TextWriterTraceListener(globalOptions.LogFile);
             var collection = new ServiceCollection();
-            SetupServices(collection, globalOptions, listener);
+            SetupServices(collection, globalOptions);
             var provider = collection.BuildServiceProvider();
             context.BindingContext.AddService<IServiceProvider>(_ => provider);
             var logger = provider.GetRequiredService<ILogger<Program>>();
@@ -157,9 +156,32 @@ This command will forcibly revert migrated assets that have failed back to their
             logger.LogInformation("See file {file} for detailed logs.", globalOptions.LogFile);
         }
 
-        static void SetupServices(IServiceCollection collection, GlobalOptions options, TraceListener listener)
+        static LogEventLevel MapLevel(LogLevel logLevel)
         {
-            var console = AnsiConsole.Console;
+            return logLevel switch
+            {
+                LogLevel.Trace => LogEventLevel.Verbose,
+                LogLevel.Debug => LogEventLevel.Debug,
+                LogLevel.Information => LogEventLevel.Information,
+                LogLevel.Warning => LogEventLevel.Warning,
+                LogLevel.Error => LogEventLevel.Error,
+                LogLevel.Critical => LogEventLevel.Fatal,
+                _ => LogEventLevel.Information
+            };
+        }
+
+        static void SetupServices(IServiceCollection collection, GlobalOptions options)
+        {
+            var settings = new AnsiConsoleSettings
+            {
+                Interactive = options.Interactive ? InteractionSupport.Detect : InteractionSupport.No
+            };
+            var console = AnsiConsole.Create(settings);
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .Enrich.FromLogContext()
+                .WriteTo.File(options.LogFile)
+                .CreateLogger();
 
             collection
                 .AddSingleton<TokenCredential>(new DefaultAzureCredential(includeInteractiveCredentials: true))
@@ -169,22 +191,30 @@ This command will forcibly revert migrated assets that have failed back to their
                 .AddSingleton<TemplateMapper>()
                 .AddSingleton<AzureResourceProvider>()
                 .AddSingleton<TransformFactory>()
-                .AddLogging(builder =>
-                {
-                    var logSwitch = new SourceSwitch("migration")
-                    {
-                        Level = SourceLevels.All
-                    };
-                    LogEventFilterDelegate filter = (in LogEventContext context) => context.EventId != Events.ShakaPackager;
+                .AddLogging(builder => {
                     builder
                         .SetMinimumLevel(LogLevel.Trace)
-                        .AddSpectreConsole(builder =>
-                            builder
-                                .SetMinimumLevel(options.LogLevel)
-                                .SetLogEventFilter(filter)
-                                .UseSerilogConsoleStyle()
-                                .UseConsole(console))
-                        .AddTraceSource(logSwitch, listener);
+                        .AddSerilog(dispose: true);
+                    if (options.Interactive)
+                    {
+                        builder.AddSpectreConsole(opts => opts
+                            .SetMinimumLevel(options.LogLevel)
+                            .SetLogEventFilter((in LogEventContext ctxt) => ctxt.EventId != Events.ShakaPackager));
+                    }
+                    else
+                    {
+                        builder.AddConsole(builder =>
+                        {
+                            builder.FormatterName = ConsoleFormatterNames.Simple;
+                            builder.LogToStandardErrorThreshold = options.LogLevel;
+                        });
+                    }
+                })
+                .Configure<SimpleConsoleFormatterOptions>(options =>
+                {
+                    options.SingleLine = true;
+                    options.TimestampFormat = "HH:mm:ss ";
+                    options.IncludeScopes = false;
                 });
             if (options.CloudType == CloudType.Local)
             {
@@ -192,8 +222,7 @@ This command will forcibly revert migrated assets that have failed back to their
             }
             else
             {
-                collection
-                    .AddSingleton<ICloudProvider, AzureProvider>();
+                collection.AddSingleton<ICloudProvider, AzureProvider>();
             }
         }
 

--- a/ams/AccountMigrator.cs
+++ b/ams/AccountMigrator.cs
@@ -10,7 +10,6 @@ namespace AMSMigrate.Ams
     /// </summary>
     internal class AccountMigrator : BaseMigrator
     {
-        private readonly ILogger _logger;
         private string _accountName;
 
         public AccountMigrator(
@@ -18,11 +17,10 @@ namespace AMSMigrate.Ams
             string accountName,
             IAnsiConsole console,
             ILogger<AccountMigrator> logger,
-            TokenCredential credential) :
-            base(options, console, credential)
+            TokenCredential credential) : 
+            base(options, console, credential, logger)
         {
             _accountName = accountName;
-            _logger = logger;
         }
 
         public override async Task MigrateAsync(CancellationToken cancellationToken)

--- a/ams/AssetAnalyzer.cs
+++ b/ams/AssetAnalyzer.cs
@@ -14,7 +14,6 @@ namespace AMSMigrate.Ams
 {
     internal class AssetAnalyzer : BaseMigrator
     {
-        private readonly ILogger _logger;
         private readonly AnalysisOptions _analysisOptions;
         private readonly IMigrationTracker<BlobContainerClient, AssetMigrationResult> _tracker;
 
@@ -25,11 +24,10 @@ namespace AMSMigrate.Ams
             IMigrationTracker<BlobContainerClient, AssetMigrationResult> tracker,
             TokenCredential credential,
             ILogger<AssetAnalyzer> logger)
-            : base(globalOptions, console, credential)
+            : base(globalOptions, console, credential, logger)
         {
             _analysisOptions = analysisOptions;
             _tracker = tracker;
-            _logger = logger;
         }
 
         private async Task<AnalysisResult> AnalyzeAsync(MediaAssetResource asset, BlobServiceClient storage, CancellationToken cancellationToken)

--- a/ams/AssetMigrator.cs
+++ b/ams/AssetMigrator.cs
@@ -13,7 +13,6 @@ namespace AMSMigrate.Ams
 {
     internal class AssetMigrator : BaseMigrator
     {
-        private readonly ILogger _logger;
         private readonly TransformFactory _transformFactory;
         private readonly AssetOptions _options;
         private readonly IMigrationTracker<BlobContainerClient, AssetMigrationResult> _tracker;
@@ -26,11 +25,10 @@ namespace AMSMigrate.Ams
             IMigrationTracker<BlobContainerClient, AssetMigrationResult> tracker,
             ILogger<AssetMigrator> logger,
             TransformFactory transformFactory) :
-            base(globalOptions, console, credential)
+            base(globalOptions, console, credential, logger)
         {
             _options = assetOptions;
             _tracker = tracker;
-            _logger = logger;
             _transformFactory = transformFactory;
         }
 

--- a/ams/BaseMigrator.cs
+++ b/ams/BaseMigrator.cs
@@ -3,6 +3,7 @@ using Azure.Core;
 using Azure.Monitor.Query;
 using Azure.Monitor.Query.Models;
 using Azure.ResourceManager.Media;
+using Microsoft.Extensions.Logging;
 using Spectre.Console;
 using System.Threading.Channels;
 
@@ -16,14 +17,17 @@ namespace AMSMigrate.Ams
         protected readonly GlobalOptions _globalOptions;
         protected readonly MetricsQueryClient _metricsQueryClient;
         protected readonly IAnsiConsole _console;
+        protected readonly ILogger _logger;
 
         public BaseMigrator(
             GlobalOptions options,
             IAnsiConsole console,
-            TokenCredential credential)
+            TokenCredential credential,
+            ILogger logger)
         {
             _globalOptions = options;
             _console = console;
+            _logger = logger;
             _resourceProvider = new AzureResourceProvider(credential, options);
             _metricsQueryClient = new MetricsQueryClient(credential);
         }
@@ -119,6 +123,7 @@ namespace AMSMigrate.Ams
                         task.MaxValue = value;
                     }
                     task.Value = value;
+                    _logger.LogDebug("{description}: {current}/{total} {unit}", description, value, totalValue, unit);
                     context.Refresh();
                 }
             });

--- a/ams/CleanupCommand.cs
+++ b/ams/CleanupCommand.cs
@@ -11,7 +11,6 @@ namespace AMSMigrate.Ams
 {
     internal class CleanupCommand : BaseMigrator
     {
-        private readonly ILogger _logger;
         private readonly CleanupOptions _options;
         private readonly IMigrationTracker<BlobContainerClient, AssetMigrationResult> _tracker;
 
@@ -21,10 +20,9 @@ namespace AMSMigrate.Ams
             TokenCredential credential,
             IMigrationTracker<BlobContainerClient, AssetMigrationResult> tracker,
             ILogger<CleanupCommand> logger)
-            : base(globalOptions, console, credential)
+            : base(globalOptions, console, credential, logger)
         {
             _options = cleanupOptions;
-            _logger = logger;
             _tracker = tracker;
         }
 

--- a/ams/KeysMigrator.cs
+++ b/ams/KeysMigrator.cs
@@ -9,7 +9,6 @@ namespace AMSMigrate.Ams
 {
     internal class KeysMigrator : BaseMigrator
     {
-        private readonly ILogger _logger;
         private readonly KeyOptions _keyOptions;
         private readonly ISecretUploader _secretUploader;
         private readonly TemplateMapper _templateMapper;
@@ -22,9 +21,8 @@ namespace AMSMigrate.Ams
             TemplateMapper templateMapper,
             ICloudProvider cloudProvider,
             TokenCredential credential) :
-            base(globalOptions, console, credential)
+            base(globalOptions, console, credential, logger)
         {
-            _logger = logger;
             _keyOptions = keyOptions;
             _templateMapper = templateMapper;
             _secretUploader = cloudProvider.GetSecretProvider(keyOptions);

--- a/ams/ResetCommand.cs
+++ b/ams/ResetCommand.cs
@@ -11,7 +11,6 @@ namespace AMSMigrate.Ams
 {
     internal class ResetCommand : BaseMigrator
     {
-        private readonly ILogger _logger;
         private readonly ResetOptions _options;
         private readonly IMigrationTracker<BlobContainerClient, AssetMigrationResult> _tracker;
         internal const string AssetTypeKey = "AssetType";
@@ -25,10 +24,9 @@ namespace AMSMigrate.Ams
             TokenCredential credential,
             IMigrationTracker<BlobContainerClient, AssetMigrationResult> tracker,
             ILogger<ResetCommand> logger)
-         : base(globalOptions, console, credential)
+         : base(globalOptions, console, credential, logger)
         {
             _options = resetOptions;
-            _logger = logger;
             _tracker = tracker;
         }
 

--- a/ams/StorageMigrator.cs
+++ b/ams/StorageMigrator.cs
@@ -13,7 +13,6 @@ namespace AMSMigrate.Ams
 {
     internal class StorageMigrator : BaseMigrator
     {
-        private readonly ILogger _logger;
         private readonly TransformFactory _transformFactory;
         private readonly StorageOptions _storageOptions;
         private readonly IMigrationTracker<BlobContainerClient, AssetMigrationResult> _tracker;
@@ -26,12 +25,11 @@ namespace AMSMigrate.Ams
             TokenCredential credentials,
             TransformFactory transformFactory,
             ILogger<StorageMigrator> logger) :
-            base(options, console, credentials)
+            base(options, console, credentials, logger)
         {
             _storageOptions = storageOptions;
             _tracker = tracker;
             _transformFactory = transformFactory;
-            _logger = logger;
         }
 
         public override async Task MigrateAsync(CancellationToken cancellationToken)

--- a/contracts/GlobalOptions.cs
+++ b/contracts/GlobalOptions.cs
@@ -15,6 +15,9 @@ namespace AMSMigrate.Contracts
 
         public string LogFile => Path.Combine(LogDirectory, _logFile);
         public string ReportFile => Path.Combine(LogDirectory, _reportFile);
+
+        // Disable interactivity on Linux for the hang issue.
+        public bool Interactive { get; set; } = !OperatingSystem.IsLinux();
     }
 
 }


### PR DESCRIPTION
Only use spectre console logging on Windows. Disabled on Linux but can be enabled with code change. 
Spectre console is still used for progress but without the interactivity. 
Use serilog for file logging for more flexibility.
Fixes #170 