### PR TITLE
Add LocatorIds into the report page for asset analyzer command

### DIFF
--- a/ams/AssetAnalyzer.cs
+++ b/ams/AssetAnalyzer.cs
@@ -45,26 +45,14 @@ namespace AMSMigrate.Ams
                 }
 
                 // Get a list of LocatorIds if they exist.
-
-                string locatorIds = "";
                 var locators = asset.GetStreamingLocatorsAsync();
 
                 await foreach (var locator in locators)
                 {
                     if (locator.StreamingLocatorId != null && locator.StreamingLocatorId != Guid.Empty)
                     {
-                        if (locatorIds != "")
-                        {
-                            locatorIds += "\n;--------\n";
-                        }
-
-                        locatorIds += locator.StreamingLocatorId.Value.ToString("D");
+                        result.LocatorIds.Add(locator.StreamingLocatorId.Value.ToString("D"));
                     }                    
-                }
-
-                if (!string.IsNullOrEmpty(locatorIds))
-                {
-                    result.LocatorIds = locatorIds;
                 }
 
                 // The asset container exists, try to check the metadata list first.

--- a/ams/AssetStats.cs
+++ b/ams/AssetStats.cs
@@ -35,7 +35,7 @@ namespace AMSMigrate.Ams
                 Interlocked.Increment(ref _streamable);
             }
 
-            if (string.IsNullOrEmpty(result.LocatorIds))
+            if (result.LocatorIds.Count == 0)
             {
                 Interlocked.Increment(ref _noLocators);
             }

--- a/ams/AssetStats.cs
+++ b/ams/AssetStats.cs
@@ -35,7 +35,7 @@ namespace AMSMigrate.Ams
                 Interlocked.Increment(ref _streamable);
             }
 
-            if (result.Locators == 0)
+            if (string.IsNullOrEmpty(result.LocatorIds))
             {
                 Interlocked.Increment(ref _noLocators);
             }

--- a/ams/ReportGenerator.cs
+++ b/ams/ReportGenerator.cs
@@ -70,7 +70,19 @@ namespace AMSMigrate.Ams
         {
             lock (this)
             {
-                _writer.Write($"<tr><td>{result.AssetName}</td><td>{result.AssetType}</td><td>{result.LocatorIds}</td><td>{result.Status}</td><td>");
+                string locatorIds = "";
+
+                foreach (var locId in result.LocatorIds)
+                {
+                    if (!string.IsNullOrEmpty(locatorIds))
+                    {
+                        locatorIds += ";\n";
+                    }
+
+                    locatorIds += locId;
+                }
+
+                _writer.Write($"<tr><td>{result.AssetName}</td><td>{result.AssetType}</td><td>{locatorIds}</td><td>{result.Status}</td><td>");
                 if (result.OutputHlsUrl != null)
                     _writer.Write($"<a href=\"{result.OutputHlsUrl}\">{result.OutputHlsUrl}</a>");
 

--- a/ams/ReportGenerator.cs
+++ b/ams/ReportGenerator.cs
@@ -46,11 +46,12 @@ namespace AMSMigrate.Ams
     <table>
       <thead>
       <tr>
-        <th style=""width:15%"">Asset Name</t>
+        <th style=""width:10%"">Asset Name</t>
         <th style=""width:5%"">AssetType</th>
-        <th style=""width:8%"">MigrateStatus</th>
-        <th style=""width:36%"">OutputHlsUrl</th>
-        <th style=""width:36%"">OutputDashUrl</th>
+        <th style=""width:10%"">LocatorIds</th>
+        <th style=""width:7%"">MigrateStatus</th>
+        <th style=""width:34%"">OutputHlsUrl</th>
+        <th style=""width:34%"">OutputDashUrl</th>
       </tr>
       </thead>
       <tbody>");
@@ -69,7 +70,7 @@ namespace AMSMigrate.Ams
         {
             lock (this)
             {
-                _writer.Write($"<tr><td>{result.AssetName}</td><td>{result.AssetType}</td><td>{result.Status}</td><td>");
+                _writer.Write($"<tr><td>{result.AssetName}</td><td>{result.AssetType}</td><td>{result.LocatorIds}</td><td>{result.Status}</td><td>");
                 if (result.OutputHlsUrl != null)
                     _writer.Write($"<a href=\"{result.OutputHlsUrl}\">{result.OutputHlsUrl}</a>");
 

--- a/transform/AnalyzeTransform.cs
+++ b/transform/AnalyzeTransform.cs
@@ -9,11 +9,13 @@ namespace AMSMigrate.Transform
             : base(status, outputPath, assetType, manifestName)
         {
             AssetName = assetName;
+
+            LocatorIds = new List<string>();
         }
 
         // A list of Locator Guids of the asset,
         // it can have zero or multiple GUIDs.
-        public string? LocatorIds { get; set; }
+        public List<string> LocatorIds { get; }
 
         public string AssetName { get; set; }
 

--- a/transform/AnalyzeTransform.cs
+++ b/transform/AnalyzeTransform.cs
@@ -5,14 +5,15 @@ namespace AMSMigrate.Transform
 {
     class AnalysisResult : AssetMigrationResult
     {
-        public AnalysisResult(string assetName, MigrationStatus status, int locators, Uri? outputPath = null, string? assetType = null, string? manifestName = null)
+        public AnalysisResult(string assetName, MigrationStatus status, Uri? outputPath = null, string? assetType = null, string? manifestName = null)
             : base(status, outputPath, assetType, manifestName)
         {
             AssetName = assetName;
-            Locators = locators;
         }
 
-        public int Locators { get; internal set; }
+        // A list of Locator Guids of the asset,
+        // it can have zero or multiple GUIDs.
+        public string? LocatorIds { get; set; }
 
         public string AssetName { get; set; }
 


### PR DESCRIPTION
Description:

  When reporting the result to HTML page, to help customers to figure out the mapping
  between streaing Url on input asset and the streaming URL of the generated output asset,
  this change adds a new column in the report page to include LocatorIds for each input asset,
  if the locatorIds (Guid) are available.

  One input can have zero or multiple locatorIds, when it has multiple locatorIds, the report page uses
  ";---------" as a separator line between two locators.

  Adjust the percentage of each column in the report page, use it as guideline, the column length is not guaranteed
  if the asset name contains a word with a long list of characters without separators like ',-' etc.

  Some minor fix to make it report correct number of assets without locators.