### PR TITLE
Report assest migration details in both JSON and HTML format

### DIFF
--- a/AnalysisOptionsBinder.cs
+++ b/AnalysisOptionsBinder.cs
@@ -39,17 +39,6 @@ Visit https://learn.microsoft.com/en-us/azure/media-services/latest/filter-order
             Arity = ArgumentArity.ZeroOrOne
         };
 
-        private readonly Option<AnalysisType> _analysisType = new(
-            aliases: new[] { "-t", "--analysis-type" },
-            () => AnalysisType.Report,
-            description: @"The kind of analysis to do.
-Summary - Summary of migration
-Detailed - A detailed classification of assets,
-Report - A migration report")
-        {
-            IsRequired = false
-        };
-
         const int DefaultBatchSize = 5;
         private readonly Option<int> _batchSize = new(
             aliases: new[] { "--batch-size", "-b" },
@@ -65,7 +54,6 @@ Report - A migration report")
             command.AddOption(_creationTimeStart);
             command.AddOption(_creationTimeEnd);
             command.AddOption(_filter);
-            command.AddOption(_analysisType);
             command.AddOption(_batchSize);
             return command;
         }
@@ -77,7 +65,6 @@ Report - A migration report")
                 bindingContext.ParseResult.GetValueForOption(_creationTimeStart),
                 bindingContext.ParseResult.GetValueForOption(_creationTimeEnd),
                 bindingContext.ParseResult.GetValueForOption(_filter),
-                bindingContext.ParseResult.GetValueForOption(_analysisType),
                 bindingContext.ParseResult.GetValueForOption(_batchSize)
             );
         }

--- a/contracts/AnalysisOptions.cs
+++ b/contracts/AnalysisOptions.cs
@@ -1,11 +1,4 @@
 ﻿namespace AMSMigrate.Contracts
 {
-    public enum AnalysisType
-    {
-        Summary,
-        Detailed,
-        Report
-    }
-
-    public record AnalysisOptions(string AccountName, DateTimeOffset? CreationTimeStart, DateTimeOffset? CreationTimeEnd, string? ResourceFilter, AnalysisType AnalysisType, int BatchSize);
+    public record AnalysisOptions(string AccountName, DateTimeOffset? CreationTimeStart, DateTimeOffset? CreationTimeEnd, string? ResourceFilter, int BatchSize);
 }

--- a/contracts/GlobalOptions.cs
+++ b/contracts/GlobalOptions.cs
@@ -11,10 +11,13 @@ namespace AMSMigrate.Contracts
     {
         static private readonly string dateTimeNow = $"{DateTime.Now:HH_mm_ss}";
         private readonly string _logFile = $"MigrationLog_{dateTimeNow}.txt";
-        private readonly string _reportFile = $"Report_{dateTimeNow}.html";
+        private readonly string _htmlReportFile = $"Report_{dateTimeNow}.html";
+        private readonly string _jsonReportFile = $"Report_{dateTimeNow}.json";
 
         public string LogFile => Path.Combine(LogDirectory, _logFile);
-        public string ReportFile => Path.Combine(LogDirectory, _reportFile);
+        public string HtmlReportFile => Path.Combine(LogDirectory, _htmlReportFile);
+
+        public string JsonReportFile => Path.Combine(LogDirectory, _jsonReportFile);
 
         // Disable interactivity on Linux for the hang issue.
         public bool Interactive { get; set; } = !OperatingSystem.IsLinux();


### PR DESCRIPTION
Description:

   Get rid of option --analysis-type from analyze comamnd.

   The analyze command always report Asset Summary and Asset Formats on the Console window at the end,
   Besides the regular log file, the command always generates html file, json file for the asset migration detail report.

   A typical output at the end is like below:

.................................................. ..................................................

   Asset Summary
+------------------+
¦ Total       ¦ 24 ¦
¦ Streamable  ¦ 11 ¦
¦ Migrated    ¦ 9  ¦
¦ Failed      ¦ 0  ¦
¦ Skipped     ¦ 2  ¦
¦ No locators ¦ 10 ¦
+------------------+
    Asset Formats
+-------------------+
¦ mp4-v3    ¦ 8     ¦
¦ fmp4      ¦ 3     ¦
¦ m3u8-aapl ¦ 1     ¦
¦ vod-fmp4  ¦ 10    ¦
¦ non_ism   ¦ 2     ¦
+-------------------+
[2:50:15 PM Info] See file D:\GitHub\azure-media-migration\bin\Debug\net6.0\Report_14_49_38.html for detailed html
report.
[2:50:15 PM Info] See file D:\GitHub\azure-media-migration\bin\Debug\net6.0\Report_14_49_38.json for detailed json
report.
[2:50:15 PM Info] See file D:\GitHub\azure-media-migration\bin\Debug\net6.0\MigrationLog_14_49_38.txt for detailed logs.

..........