### PR TITLE
When migrating a video with a secondary audio component in it, the vi…

### DIFF
--- a/migrationTool/transform/ShakaPackager.cs
+++ b/migrationTool/transform/ShakaPackager.cs
@@ -128,7 +128,7 @@ namespace AMSMigrate.Transform
             {
                 if (!string.IsNullOrEmpty(manifests[i]))
                 {
-                    var source = t.Parameters.SingleOrDefault(p => p.Name == TRANSCRIPT_SOURCE)?.Value ?? t.Source;
+                    var source = t.Parameters?.SingleOrDefault(p => p.Name == TRANSCRIPT_SOURCE)?.Value ?? t.Source;
                     var ext = t.IsMultiFile ? (t is TextTrack ? VTT_FILE : MEDIA_FILE) : string.Empty;
                     var file = $"{source}{ext}";
                     var index = Inputs.IndexOf(file);


### PR DESCRIPTION
When migrating a video with a secondary audio component in it, the video track has Parameters set to null. It was throwing an exception here.