### PR TITLE
Report the OutputHlsUrl and OutputDashUrl in report page only when th…

### DIFF
--- a/migrationTool/transform/AnalyzeTransform.cs
+++ b/migrationTool/transform/AnalyzeTransform.cs
@@ -19,8 +19,8 @@ namespace AMSMigrate.Transform
 
         public string AssetName { get; set; }
 
-        public Uri? OutputHlsUrl => OutputPath != null ? new Uri(OutputPath!, (ManifestName + ".m3u8")) : null;
+        public Uri? OutputHlsUrl => OutputPath != null && ManifestName != null ? new Uri(OutputPath!, (ManifestName + ".m3u8")) : null;
 
-        public Uri? OutputDashUrl => OutputPath != null ? new Uri(OutputPath!, (ManifestName + ".mpd")) : null;
+        public Uri? OutputDashUrl => OutputPath != null && ManifestName != null ? new Uri(OutputPath!, (ManifestName + ".mpd")) : null;
     }
 }


### PR DESCRIPTION
…e input asset contains .ism file

Description

   The OutputHlsUrl and OutputDashUrl are reported as empty in the report file for below scenarios:
     (1) The migration status is Failed.
     (2) The migration status is skipped.
     (3) The input assetType is non_ism.