### PR TITLE
Fix to allow multi language audio to be packaged correctly.

### DIFF
--- a/migrationTool/transform/ShakaPackager.cs
+++ b/migrationTool/transform/ShakaPackager.cs
@@ -139,7 +139,7 @@ namespace AMSMigrate.Transform
                     var stream = t.Type.ToString().ToLowerInvariant();
                     var language = string.IsNullOrEmpty(t.SystemLanguage) || t.SystemLanguage == "und" ? string.Empty : $",language={t.SystemLanguage},";
                     var role = t is TextTrack ? $",dash_role={values[text_tracks++ % values.Length].ToString().ToLowerInvariant()}" : string.Empty;
-                    return $"stream={stream},in={inputFile},out={outputs[i]},playlist_name={manifests[i]}{language}{drm_label}{role}";
+                    return $"stream={t.TrackID - 1},in={inputFile},out={outputs[i]},playlist_name={manifests[i]}{language}{drm_label}{role}";
                 }
                 else
                 {


### PR DESCRIPTION
Use stream id instead of stream type to select multiple audios correctly. Assumes that track id is stream_index + 1 which works 99% of time but could be incorrect some times.