### PR TITLE
Fix an exception that is thrown when the manifest is valid but does not contain trackId data

### DIFF
--- a/migrationTool/contracts/Manifest.cs
+++ b/migrationTool/contracts/Manifest.cs
@@ -51,9 +51,9 @@ namespace AMSMigrate.Contracts
         // Check if the track is stored as one file per fragment.
         public bool IsMultiFile => string.IsNullOrEmpty(Path.GetExtension(Source));
 
-        public uint TrackID => uint.Parse(Parameters.Single(p => p.Name == "trackID").Value);
+        public uint TrackID => uint.Parse(Parameters?.SingleOrDefault(p => p.Name == "trackID")?.Value ?? "1");
 
-        public string TrackName => Parameters.SingleOrDefault(p => p.Name == "trackName")?.Value ?? Type.ToString().ToLower();
+        public string TrackName => Parameters?.SingleOrDefault(p => p.Name == "trackName")?.Value ?? Type.ToString().ToLower();
     }
 
     public class VideoTrack : Track


### PR DESCRIPTION
We have several assets in our media services that have a ISM file like this:

```
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<smil xmlns="http://www.w3.org/2001/SMIL20/Language">
    <head>
        <meta content="mp4" name="formats"/>
    </head>
    <body>
        <switch>
            <video src="file_1000_640x360_1000.mp4"/>
            <audio src="file_1000_640x360_1000.mp4" systemBitrate="128000" title="AAC_eng_ch2_128kbps"/>
        </switch>
    </body>
</smil>
```

When processing this asset using the migration tool, an exception is thrown:

```
2024-05-29 13:17:35.605 +00:00 [ERR] Failed to migrate asset 18c23a5d-1500-80c4-015f-f1e577fcccbc Error:System.ArgumentNullException: Value cannot be null. (Parameter 'source')
   at System.Linq.ThrowHelper.ThrowArgumentNullException(ExceptionArgument argument)
   at System.Linq.Enumerable.TryGetSingle[TSource](IEnumerable`1 source, Func`2 predicate, Boolean& found)
   at System.Linq.Enumerable.Single[TSource](IEnumerable`1 source, Func`2 predicate)
   at AMSMigrate.Contracts.Track.get_TrackID() in S:\Tools\Microsoft\azure-media-migration\migrationTool\contracts\Manifest.cs:line 54
   at AMSMigrate.Transform.ShakaPackager.<>c__DisplayClass6_0.<GetArguments>b__0(Track t, Int32 i) in S:\Tools\Microsoft\azure-media-migration\migrationTool\transform\ShakaPackager.cs:line 142
   at System.Linq.Enumerable.SelectIterator[TSource,TResult](IEnumerable`1 source, Func`3 selector)+MoveNext()
   at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
   at AMSMigrate.Transform.ShakaPackager.GetArguments(IList`1 inputs, IList`1 outputs, IList`1 manifests) in S:\Tools\Microsoft\azure-media-migration\migrationTool\transform\ShakaPackager.cs:line 127
   at AMSMigrate.Transform.ShakaPackager.RunAsync(String workingDirectory, String[] inputs, String[] outputs, String[] manifests, CancellationToken cancellationToken) in S:\Tools\Microsoft\azure-media-migration\migrationTool\transform\ShakaPackager.cs:line 297
   at AMSMigrate.Transform.PackageTransform.TransformAsync(AssetDetails details, ValueTuple`2 outputPath, CancellationToken cancellationToken) in S:\Tools\Microsoft\azure-media-migration\migrationTool\transform\PackageTransform.cs:line 161
```

This PR fixes this exception by adding a default value for TrackID.