### PR TITLE
Update shaka-packager to v3.2.0

### DIFF
--- a/migrationTool/AMSMigrate.csproj
+++ b/migrationTool/AMSMigrate.csproj
@@ -69,9 +69,9 @@
     </None>
   </ItemGroup>
   <PropertyGroup>
-    <ShakaWin>https://github.com/shaka-project/shaka-packager/releases/download/v2.6.1/packager-win-x64.exe</ShakaWin>
-    <ShakaLinux>https://github.com/shaka-project/shaka-packager/releases/download/v2.6.1/packager-linux-x64</ShakaLinux>
-    <ShakaOSX>https://github.com/shaka-project/shaka-packager/releases/download/v2.6.1/packager-osx-x64</ShakaOSX>
+    <ShakaWin>https://github.com/shaka-project/shaka-packager/releases/download/v3.2.0/packager-win-x64.exe</ShakaWin>
+    <ShakaLinux>https://github.com/shaka-project/shaka-packager/releases/download/v3.2.0/packager-linux-x64</ShakaLinux>
+    <ShakaOSX>https://github.com/shaka-project/shaka-packager/releases/download/v3.2.0/packager-osx-x64</ShakaOSX>
     <Company>Microsoft Corporation</Company>
   </PropertyGroup>
   <Target Name="DownloadShakaPackager" BeforeTargets="Build">


### PR DESCRIPTION
Update shaka-packager to v3.2.0, on my tests the migration still works and I ran into no new issues.

Please note that the new version of shaka-packager for Windows requires latest vc_redist.x64.exe from https://aka.ms/vs/17/release/vc_redist.x64.exe