### PR TITLE
Add patching to manifest to workaround several issues

### DIFF
--- a/migrationTool/ams/AssetMigrator.cs
+++ b/migrationTool/ams/AssetMigrator.cs
@@ -46,8 +46,10 @@ namespace AMSMigrate.Ams
                 account.Id.ToString(),
                 "AssetCount",
                 cancellationToken: cancellationToken);
-
-            _logger.LogInformation("The total asset count of the media account is {count}.", totalAssets);
+            if (totalAssets > 0)
+            {
+                _logger.LogInformation("The total asset count of the media account is {count}.", totalAssets);
+            }
 
             var resourceFilter = GetAssetResourceFilter(_options.ResourceFilter,
                                                         _options.CreationTimeStart,

--- a/migrationTool/contracts/Manifest.cs
+++ b/migrationTool/contracts/Manifest.cs
@@ -1,8 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using System.Text;
 using System.Xml.Serialization;
-using Azure.Monitor.Query.Models;
-using Azure.ResourceManager.Media.Models;
 
 namespace AMSMigrate.Contracts
 {
@@ -132,31 +130,6 @@ namespace AMSMigrate.Contracts
                 {
                     track.SystemBitrate = systemBitrate;
                 }
-            }
-
-            // find tracks that have the same source and drop the audio track and the video tracks with the lowest bitrates
-            var tracksToRemove = new List<Track>();
-            var duplicateSourceGroups = manifest.Body.Tracks.GroupBy(x => x.Source).Where(x => x.Count() > 1);
-            foreach (var duplicateSourceGroup in duplicateSourceGroups)
-            {
-                var videoTracks = duplicateSourceGroup.Where(x => x.Type == StreamType.Video).OrderBy(x => x.SystemBitrate).ThenBy(x => x.TrackID).ToArray();
-                int videoTrackCount = videoTracks.Length;
-                if (videoTrackCount > 0)
-                {
-                    var audioTrack = duplicateSourceGroup.FirstOrDefault(x => x.Type == StreamType.Audio);
-                    if (audioTrack is not null)
-                    {
-                        tracksToRemove.Add(audioTrack);
-                    }
-                    if (videoTrackCount > 1)
-                    {
-                        tracksToRemove.AddRange(videoTracks.Take(videoTrackCount - 1));
-                    }
-                }
-            }
-            if (tracksToRemove.Any())
-            {
-                manifest.Body.Tracks = manifest.Body.Tracks.ToList().Except(tracksToRemove).ToArray();
             }
 
             return manifest;

--- a/migrationTool/contracts/Manifest.cs
+++ b/migrationTool/contracts/Manifest.cs
@@ -121,6 +121,17 @@ namespace AMSMigrate.Contracts
             var manifest = serializer.Deserialize(new StreamReader(stream, Encoding.UTF8)) as Manifest;
             if (manifest == null) throw new ArgumentException("Invalid data", nameof(stream));
             manifest.FileName = filename;
+
+            // fix missing SystemBitrate, try to determine from source name
+            foreach (var track in manifest.Body.Tracks.Where(x => x.SystemBitrate <= 0))
+            {
+                string[] sourceParts = Path.GetFileNameWithoutExtension(track.Source).Split('_', StringSplitOptions.RemoveEmptyEntries);
+                if (sourceParts.Length > 0 && int.TryParse(sourceParts.Last(), out int systemBitrate))
+                {
+                    track.SystemBitrate = systemBitrate;
+                }
+            }
+
             return manifest;
         }
     }


### PR DESCRIPTION
I've added some manifest patching to the code:

* Try to determine the SystemBitrate value from the Source value, on most assets created by AMS encoder, the bitrate value is part of the source name (schema is <name>_<width>x<height>_<bitrate>.mp4)
* If the source manifest has an additional audio track that is identical to one of the video tracks, the audio track can be removed (fixes #250)
* Make sure that tracks that use the same source get consolidated, only the track with the highest bitrate should be taken

Please review.