### PR TITLE
Duplicate video tracks when track id is missing in manifest.

### DIFF
--- a/migrationTool/transform/PackageTransform.cs
+++ b/migrationTool/transform/PackageTransform.cs
@@ -85,7 +85,7 @@ namespace AMSMigrate.Transform
                 var inputPaths = inputFiles.Select(f => Path.Combine(workingDirectory, f))
                     .ToArray();
 
-                // Anything not package and can be uploaded is uploaded directly.
+                // Anything not packaged and can be uploaded is uploaded directly.
                 var blobs = await container.GetListOfBlobsRemainingAsync(manifest, cancellationToken);
                 allTasks.Add(Task.WhenAll(blobs.Select(async blob =>
                 {

--- a/migrationTool/transform/ShakaPackager.cs
+++ b/migrationTool/transform/ShakaPackager.cs
@@ -139,7 +139,8 @@ namespace AMSMigrate.Transform
                     var stream = t.Type.ToString().ToLowerInvariant();
                     var language = string.IsNullOrEmpty(t.SystemLanguage) || t.SystemLanguage == "und" ? string.Empty : $",language={t.SystemLanguage},";
                     var role = t is TextTrack ? $",dash_role={values[text_tracks++ % values.Length].ToString().ToLowerInvariant()}" : string.Empty;
-                    return $"stream={t.TrackID - 1},in={inputFile},out={outputs[i]},playlist_name={manifests[i]}{language}{drm_label}{role}";
+                    var useType = SelectedTracks.Count(x => x.Source == t.Source && x.Type == t.Type) == 1;
+                    return $"stream={(useType ? stream: t.TrackID - 1)},in={inputFile},out={outputs[i]},playlist_name={manifests[i]}{language}{drm_label}{role}";
                 }
                 else
                 {


### PR DESCRIPTION
Do not assume track id to be 1 for all tracks.
But if audio and video are in same file both can't be track 1.
Use stream type instead of track id where possible.
Fixes #250 