### PR TITLE
Update AssetMigrationTracker.cs to escape URLs

### DIFF
--- a/migrationTool/ams/AssetMigrationTracker.cs
+++ b/migrationTool/ams/AssetMigrationTracker.cs
@@ -86,12 +86,16 @@ namespace AMSMigrate.Ams
                 }
 
                 metadataList.TryGetValue(AssetTypeKey, out assetType);
-
+                
                 metadataList.TryGetValue(ManifestNameKey, out manifestName);
-
+                if (!string.IsNullOrEmpty(manifestName))
+                {
+                    manifestName = Uri.UnescapeDataString(manifestName);
+                }
+                
                 if (metadataList.TryGetValue(OutputPathKey, out value) && !string.IsNullOrEmpty(value))
                 {
-                    outputPath = new Uri(Uri.UnescapeDataString(value), UriKind.Absolute);
+                    outputPath = new Uri(value, UriKind.Absolute);
                 }
             }
 
@@ -126,12 +130,12 @@ namespace AMSMigrate.Ams
 
             if (!string.IsNullOrEmpty(result.ManifestName))
             {
-                metadata.Add(ManifestNameKey, result.ManifestName);
+                metadata.Add(ManifestNameKey, Uri.EscapeDataString(result.ManifestName));
             }
 
-            if (result.OutputPath != null && !string.IsNullOrEmpty(result.OutputPath.AbsoluteUri))
+            if (result.OutputPath != null)
             {
-                metadata.Add(OutputPathKey, Uri.EscapeDataString(result.OutputPath.AbsoluteUri));
+                metadata.Add(OutputPathKey, result.OutputPath.AbsoluteUri);
             }
 
             await container.SetMetadataAsync(metadata, cancellationToken: cancellationToken);

--- a/migrationTool/ams/AssetMigrationTracker.cs
+++ b/migrationTool/ams/AssetMigrationTracker.cs
@@ -87,8 +87,7 @@ namespace AMSMigrate.Ams
 
                 metadataList.TryGetValue(AssetTypeKey, out assetType);
                 
-                metadataList.TryGetValue(ManifestNameKey, out manifestName);
-                if (!string.IsNullOrEmpty(manifestName))
+                if ( metadataList.TryGetValue(ManifestNameKey, out manifestName))
                 {
                     manifestName = Uri.UnescapeDataString(manifestName);
                 }

--- a/migrationTool/ams/AssetMigrationTracker.cs
+++ b/migrationTool/ams/AssetMigrationTracker.cs
@@ -91,7 +91,7 @@ namespace AMSMigrate.Ams
 
                 if (metadataList.TryGetValue(OutputPathKey, out value) && !string.IsNullOrEmpty(value))
                 {
-                    outputPath = new Uri(value, UriKind.Absolute);
+                    outputPath = new Uri(Uri.UnescapeDataString(value), UriKind.Absolute);
                 }
             }
 
@@ -129,9 +129,9 @@ namespace AMSMigrate.Ams
                 metadata.Add(ManifestNameKey, result.ManifestName);
             }
 
-            if (result.OutputPath != null)
+            if (result.OutputPath != null && !string.IsNullOrEmpty(result.OutputPath.AbsoluteUri))
             {
-                metadata.Add(OutputPathKey, result.OutputPath.AbsoluteUri);
+                metadata.Add(OutputPathKey, Uri.EscapeDataString(result.OutputPath.AbsoluteUri));
             }
 
             await container.SetMetadataAsync(metadata, cancellationToken: cancellationToken);


### PR DESCRIPTION
Azure storage blob metadata data updates are submitted via the HTTP header which didn't allow for non-ascii characters. This change escapes the URIs that we put into the blob metadata.